### PR TITLE
Rescue dead "In Progress" tasks

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -41,6 +41,9 @@ func (p *processor) terminate() {
 }
 
 func (p *processor) start() {
+	// NOTE: The call to "restore" needs to complete before starting
+	// the processor goroutine.
+	p.restore()
 	go func() {
 		for {
 			select {
@@ -91,4 +94,13 @@ func (p *processor) exec() {
 			retryTask(p.rdb, msg, err)
 		}
 	}(task)
+}
+
+// restore moves all tasks from "in-progress" back to queue
+// to restore all unfinished tasks.
+func (p *processor) restore() {
+	err := p.rdb.moveAll(inProgress, defaultQueue)
+	if err != nil {
+		log.Printf("[SERVER ERROR] could not move tasks from %q to %q\n", inProgress, defaultQueue)
+	}
 }

--- a/rdb.go
+++ b/rdb.go
@@ -171,3 +171,16 @@ func (r *rdb) listQueues() []string {
 	}
 	return queues
 }
+
+// moveAll moves all tasks from src list to dst list.
+func (r *rdb) moveAll(src, dst string) error {
+	// TODO(hibiken): Lua script
+	txf := func(tx *redis.Tx) error {
+		length := tx.LLen(src).Val()
+		for i := 0; i < int(length); i++ {
+			tx.RPopLPush(src, dst)
+		}
+		return nil
+	}
+	return r.client.Watch(txf, src)
+}


### PR DESCRIPTION
Changes made:
- Use BRPOPLPUSH to move a task from a queue to **In-Progress** list
- Remove a task from **In-Progress** list once a worker has finished with the task
- On start, pushes the **In-Progress** tasks (if any) back to the queue

This change makes the system more resilient. It prevents data loss in case there's a server crash while workers are still working on a task or a task is waiting for an available worker.
