### PR TITLE
Rename Client Process method to Schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ func main() {
     }
 
     // process the task immediately.
-    err := client.Process(&t1, time.Now())
+    err := client.Schedule(&t1, time.Now())
 
     // process the task 24 hours later.
-    err = client.Process(&t2, time.Now().Add(24 * time.Hour))
+    err = client.Schedule(&t2, time.Now().Add(24 * time.Hour))
 
     // specify the max number of retry (default: 25)
-    err = client.Process(&t1, time.Now(), asynq.MaxRetry(1))
+    err = client.Schedule(&t1, time.Now(), asynq.MaxRetry(1))
 }
 ```
 

--- a/background_test.go
+++ b/background_test.go
@@ -33,12 +33,12 @@ func TestBackground(t *testing.T) {
 
 	bg.start(HandlerFunc(h))
 
-	client.Process(&Task{
+	client.Schedule(&Task{
 		Type:    "send_email",
 		Payload: map[string]interface{}{"recipient_id": 123},
 	}, time.Now())
 
-	client.Process(&Task{
+	client.Schedule(&Task{
 		Type:    "send_email",
 		Payload: map[string]interface{}{"recipient_id": 456},
 	}, time.Now().Add(time.Hour))

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -29,7 +29,7 @@ func BenchmarkEndToEndSimple(b *testing.B) {
 		// Create a bunch of tasks
 		for i := 0; i < count; i++ {
 			t := Task{Type: fmt.Sprintf("task%d", i), Payload: Payload{"data": i}}
-			client.Process(&t, time.Now())
+			client.Schedule(&t, time.Now())
 		}
 
 		var wg sync.WaitGroup
@@ -66,11 +66,11 @@ func BenchmarkEndToEnd(b *testing.B) {
 		// Create a bunch of tasks
 		for i := 0; i < count; i++ {
 			t := Task{Type: fmt.Sprintf("task%d", i), Payload: Payload{"data": i}}
-			client.Process(&t, time.Now())
+			client.Schedule(&t, time.Now())
 		}
 		for i := 0; i < count; i++ {
 			t := Task{Type: fmt.Sprintf("scheduled%d", i), Payload: Payload{"data": i}}
-			client.Process(&t, time.Now().Add(time.Second))
+			client.Schedule(&t, time.Now().Add(time.Second))
 		}
 
 		var wg sync.WaitGroup

--- a/client.go
+++ b/client.go
@@ -70,14 +70,14 @@ const (
 	defaultMaxRetry = 25
 )
 
-// Process registers a task to be processed at the specified time.
+// Schedule registers a task to be processed at the specified time.
 //
-// Process returns nil if the task is registered successfully,
+// Schedule returns nil if the task is registered successfully,
 // otherwise returns non-nil error.
 //
 // opts specifies the behavior of task processing. If there are conflicting
 // Option the last one overrides the ones before.
-func (c *Client) Process(task *Task, processAt time.Time, opts ...Option) error {
+func (c *Client) Schedule(task *Task, processAt time.Time, opts ...Option) error {
 	opt := composeOptions(opts...)
 	msg := &base.TaskMessage{
 		ID:      xid.New(),

--- a/client_test.go
+++ b/client_test.go
@@ -117,7 +117,7 @@ func TestClient(t *testing.T) {
 	for _, tc := range tests {
 		h.FlushDB(t, r) // clean up db before each test case.
 
-		err := client.Process(tc.task, tc.processAt, tc.opts...)
+		err := client.Schedule(tc.task, tc.processAt, tc.opts...)
 		if err != nil {
 			t.Error(err)
 			continue

--- a/doc.go
+++ b/doc.go
@@ -14,7 +14,7 @@ The Client is used to register a task to be processed at the specified time.
 	    Payload: map[string]interface{}{"user_id": 42},
 	}
 
-	err := client.Process(&t, time.Now().Add(time.Minute))
+	err := client.Schedule(&t, time.Now().Add(time.Minute))
 
 The Background is used to run the background task processing with a given
 handler.


### PR DESCRIPTION
`Process` was confusing since the calling the method does not actually process the task, but rather schedule it to be processed.