### PR TITLE
Fix Requeue and RestoreUnfinished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed restoring unfinished tasks back to correct queues.
+
 ### Changed
 
 - `asynqmon ls` command is now paginated (default 30 tasks from first page)

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -156,7 +156,7 @@ func (r *RDB) Requeue(msg *base.TaskMessage) error {
 	return redis.status_reply("OK")
 	`)
 	return script.Run(r.client,
-		[]string{base.InProgressQueue, base.DefaultQueue},
+		[]string{base.InProgressQueue, base.QueueKey(msg.Queue)},
 		string(bytes)).Err()
 }
 


### PR DESCRIPTION
`Requeue` and `RestoreUnfinished` operation were pushing all tasks back to "default" queue.
This PR fixes this by looking at "Queue" field in task message and select correct queue to push the task.