### PR TITLE
Make task handler context aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ func main() {
 
     // Use custom queue called "critical"
     err = client.Schedule(t1, time.Now(), asynq.Queue("critical"))
+
+    // Use timeout to specify how long a task may run (Default is no limit)
+    err = client.Schedule(t1, time.Now(), asynq.Timeout(30 * time.Second))
 }
 ```
 
@@ -94,7 +97,7 @@ func main() {
 // If ProcessTask return a non-nil error or panics, the task
 // will be retried after delay.
 type Handler interface {
-    ProcessTask(*Task) error
+    ProcessTask(context.Context, *asynq.Task) error
 }
 ```
 

--- a/background.go
+++ b/background.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -141,18 +142,18 @@ func NewBackground(r RedisConnOpt, cfg *Config) *Background {
 // If ProcessTask return a non-nil error or panics, the task
 // will be retried after delay.
 type Handler interface {
-	ProcessTask(*Task) error
+	ProcessTask(context.Context, *Task) error
 }
 
 // The HandlerFunc type is an adapter to allow the use of
 // ordinary functions as a Handler. If f is a function
 // with the appropriate signature, HandlerFunc(f) is a
 // Handler that calls f.
-type HandlerFunc func(*Task) error
+type HandlerFunc func(context.Context, *Task) error
 
-// ProcessTask calls fn(task)
-func (fn HandlerFunc) ProcessTask(task *Task) error {
-	return fn(task)
+// ProcessTask calls fn(ctx, task)
+func (fn HandlerFunc) ProcessTask(ctx context.Context, task *Task) error {
+	return fn(ctx, task)
 }
 
 // Run starts the background-task processing and blocks until

--- a/background_test.go
+++ b/background_test.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ func TestBackground(t *testing.T) {
 	})
 
 	// no-op handler
-	h := func(task *Task) error {
+	h := func(ctx context.Context, task *Task) error {
 		return nil
 	}
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -37,7 +38,7 @@ func BenchmarkEndToEndSimple(b *testing.B) {
 
 		var wg sync.WaitGroup
 		wg.Add(count)
-		handler := func(t *Task) error {
+		handler := func(ctx context.Context, t *Task) error {
 			wg.Done()
 			return nil
 		}
@@ -82,7 +83,7 @@ func BenchmarkEndToEnd(b *testing.B) {
 
 		var wg sync.WaitGroup
 		wg.Add(count * 2)
-		handler := func(t *Task) error {
+		handler := func(ctx context.Context, t *Task) error {
 			// randomly fail 1% of tasks
 			if rand.Intn(100) == 1 {
 				return fmt.Errorf(":(")
@@ -141,7 +142,7 @@ func BenchmarkEndToEndMultipleQueues(b *testing.B) {
 
 		var wg sync.WaitGroup
 		wg.Add(highCount + defaultCount + lowCount)
-		handler := func(t *Task) error {
+		handler := func(ctx context.Context, t *Task) error {
 			wg.Done()
 			return nil
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -42,6 +42,7 @@ func TestClient(t *testing.T) {
 						Payload: task.Payload.data,
 						Retry:   defaultMaxRetry,
 						Queue:   "default",
+						Timeout: time.Duration(0).String(),
 					},
 				},
 			},
@@ -60,6 +61,7 @@ func TestClient(t *testing.T) {
 						Payload: task.Payload.data,
 						Retry:   defaultMaxRetry,
 						Queue:   "default",
+						Timeout: time.Duration(0).String(),
 					},
 					Score: float64(time.Now().Add(2 * time.Hour).Unix()),
 				},
@@ -79,6 +81,7 @@ func TestClient(t *testing.T) {
 						Payload: task.Payload.data,
 						Retry:   3,
 						Queue:   "default",
+						Timeout: time.Duration(0).String(),
 					},
 				},
 			},
@@ -98,6 +101,7 @@ func TestClient(t *testing.T) {
 						Payload: task.Payload.data,
 						Retry:   0, // Retry count should be set to zero
 						Queue:   "default",
+						Timeout: time.Duration(0).String(),
 					},
 				},
 			},
@@ -118,6 +122,7 @@ func TestClient(t *testing.T) {
 						Payload: task.Payload.data,
 						Retry:   10, // Last option takes precedence
 						Queue:   "default",
+						Timeout: time.Duration(0).String(),
 					},
 				},
 			},
@@ -137,6 +142,7 @@ func TestClient(t *testing.T) {
 						Payload: task.Payload.data,
 						Retry:   defaultMaxRetry,
 						Queue:   "custom",
+						Timeout: time.Duration(0).String(),
 					},
 				},
 			},
@@ -156,6 +162,27 @@ func TestClient(t *testing.T) {
 						Payload: task.Payload.data,
 						Retry:   defaultMaxRetry,
 						Queue:   "high",
+						Timeout: time.Duration(0).String(),
+					},
+				},
+			},
+			wantScheduled: nil, // db is flushed in setup so zset does not exist hence nil
+		},
+		{
+			desc:      "Timeout option sets the timeout duration",
+			task:      task,
+			processAt: time.Now(),
+			opts: []Option{
+				Timeout(20 * time.Second),
+			},
+			wantEnqueued: map[string][]*base.TaskMessage{
+				"default": []*base.TaskMessage{
+					&base.TaskMessage{
+						Type:    task.Type,
+						Payload: task.Payload.data,
+						Retry:   defaultMaxRetry,
+						Queue:   "default",
+						Timeout: (20 * time.Second).String(),
 					},
 				},
 			},

--- a/doc.go
+++ b/doc.go
@@ -45,7 +45,7 @@ Example of a type that implements the Handler interface.
         // ...
     }
 
-    func (h *TaskHandler) ProcessTask(task *asynq.Task) error {
+    func (h *TaskHandler) ProcessTask(ctx context.Context, task *asynq.Task) error {
         switch task.Type {
         case "send_email":
             id, err := task.Payload.GetInt("user_id")

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -77,6 +77,12 @@ type TaskMessage struct {
 
 	// ErrorMsg holds the error message from the last failure.
 	ErrorMsg string
+
+	// Timeout specifies how long a task may run.
+	// The string value should be compatible with time.Duration.ParseDuration.
+	//
+	// Zero means no limit.
+	Timeout string
 }
 
 // ProcessInfo holds information about running background worker process.


### PR DESCRIPTION
Change Handler interface to take context as the first argument.

The context can be canceled in two scenarios (will be three in the future):

- Background worker process is shutting down
- User specified timeout duration has elapsed
- User cancels a task manually via CLI (upcoming changes)

Handler implementation should check the context to support cancelation.

This closes part of #69 