### PR TITLE
Add cancel command to the CLI

### DIFF
--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -132,9 +132,9 @@ func (p *ProcessInfo) IncrActiveWorkerCount(delta int) {
 	p.ActiveWorkerCount += delta
 }
 
-// Cancelations hold cancel functions for all in-progress tasks.
+// Cancelations is a collection that holds cancel functions for all in-progress tasks.
 //
-// Its methods are safe to be used in multiple concurrent goroutines
+// Its methods are safe to be used in multiple goroutines.
 type Cancelations struct {
 	mu          sync.Mutex
 	cancelFuncs map[string]context.CancelFunc
@@ -147,14 +147,14 @@ func NewCancelations() *Cancelations {
 	}
 }
 
-// Add adds a new cancel func to the set.
+// Add adds a new cancel func to the collection.
 func (c *Cancelations) Add(id string, fn context.CancelFunc) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.cancelFuncs[id] = fn
 }
 
-// Delete deletes a cancel func from the set given an id.
+// Delete deletes a cancel func from the collection given an id.
 func (c *Cancelations) Delete(id string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -422,7 +422,7 @@ func (r *RDB) CancelationPubSub() (*redis.PubSub, error) {
 }
 
 // PublishCancelation publish cancelation message to all subscribers.
-// The message is a string representing the task to be canceled.
+// The message is the ID for the task to be canceled.
 func (r *RDB) PublishCancelation(id string) error {
 	return r.client.Publish(base.CancelChannel, id).Err()
 }

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -410,3 +410,19 @@ func (r *RDB) ClearProcessInfo(ps *base.ProcessInfo) error {
 	key := base.ProcessInfoKey(ps.Host, ps.PID)
 	return clearProcessInfoCmd.Run(r.client, []string{base.AllProcesses, key}).Err()
 }
+
+// CancelationPubSub returns a pubsub for cancelation messages.
+func (r *RDB) CancelationPubSub() (*redis.PubSub, error) {
+	pubsub := r.client.Subscribe(base.CancelChannel)
+	_, err := pubsub.Receive()
+	if err != nil {
+		return nil, err
+	}
+	return pubsub, nil
+}
+
+// PublishCancelation publish cancelation message to all subscribers.
+// The message is a string representing the task to be canceled.
+func (r *RDB) PublishCancelation(id string) error {
+	return r.client.Publish(base.CancelChannel, id).Err()
+}

--- a/processor_test.go
+++ b/processor_test.go
@@ -67,7 +67,8 @@ func TestProcessorSuccess(t *testing.T) {
 			return nil
 		}
 		pi := base.NewProcessInfo("localhost", 1234, 10, defaultQueueConfig, false)
-		p := newProcessor(rdbClient, pi, defaultDelayFunc, nil)
+		cancelations := base.NewCancelations()
+		p := newProcessor(rdbClient, pi, defaultDelayFunc, nil, cancelations)
 		p.handler = HandlerFunc(handler)
 
 		p.start()
@@ -151,7 +152,8 @@ func TestProcessorRetry(t *testing.T) {
 			return fmt.Errorf(errMsg)
 		}
 		pi := base.NewProcessInfo("localhost", 1234, 10, defaultQueueConfig, false)
-		p := newProcessor(rdbClient, pi, delayFunc, nil)
+		cancelations := base.NewCancelations()
+		p := newProcessor(rdbClient, pi, delayFunc, nil, cancelations)
 		p.handler = HandlerFunc(handler)
 
 		p.start()
@@ -211,7 +213,8 @@ func TestProcessorQueues(t *testing.T) {
 
 	for _, tc := range tests {
 		pi := base.NewProcessInfo("localhost", 1234, 10, tc.queueCfg, false)
-		p := newProcessor(nil, pi, defaultDelayFunc, nil)
+		cancelations := base.NewCancelations()
+		p := newProcessor(nil, pi, defaultDelayFunc, nil, cancelations)
 		got := p.queues()
 		if diff := cmp.Diff(tc.want, got, sortOpt); diff != "" {
 			t.Errorf("with queue config: %v\n(*processor).queues() = %v, want %v\n(-want,+got):\n%s",
@@ -278,7 +281,8 @@ func TestProcessorWithStrictPriority(t *testing.T) {
 		}
 		// Note: Set concurrency to 1 to make sure tasks are processed one at a time.
 		pi := base.NewProcessInfo("localhost", 1234, 1 /*concurrency */, queueCfg, true /* strict */)
-		p := newProcessor(rdbClient, pi, defaultDelayFunc, nil)
+		cancelations := base.NewCancelations()
+		p := newProcessor(rdbClient, pi, defaultDelayFunc, nil, cancelations)
 		p.handler = HandlerFunc(handler)
 
 		p.start()

--- a/subscriber.go
+++ b/subscriber.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Kentaro Hibino. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package asynq
+
+import (
+	"github.com/hibiken/asynq/internal/base"
+	"github.com/hibiken/asynq/internal/rdb"
+)
+
+type subscriber struct {
+	rdb *rdb.RDB
+
+	// channel to communicate back to the long running "subscriber" goroutine.
+	done chan struct{}
+
+	// cancelations hold cancel functions for all in-progress tasks.
+	cancelations *base.Cancelations
+}
+
+func newSubscriber(rdb *rdb.RDB, cancelations *base.Cancelations) *subscriber {
+	return &subscriber{
+		rdb:          rdb,
+		done:         make(chan struct{}),
+		cancelations: cancelations,
+	}
+}
+
+func (s *subscriber) terminate() {
+	logger.info("Subscriber shutting down...")
+	// Signal the subscriber goroutine to stop.
+	s.done <- struct{}{}
+}
+
+func (s *subscriber) start() {
+	pubsub, err := s.rdb.CancelationPubSub()
+	cancelCh := pubsub.Channel()
+	if err != nil {
+		logger.error("cannot subscribe to cancelation channel: %v", err)
+		return
+	}
+	go func() {
+		for {
+			select {
+			case <-s.done:
+				pubsub.Close()
+				logger.info("Subscriber done")
+				return
+			case msg := <-cancelCh:
+				cancel := s.cancelations.Get(msg.Payload)
+				if cancel != nil {
+					cancel()
+				}
+			}
+		}
+	}()
+}

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Kentaro Hibino. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package asynq
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq/internal/base"
+	"github.com/hibiken/asynq/internal/rdb"
+)
+
+func TestSubscriber(t *testing.T) {
+	r := setup(t)
+	rdbClient := rdb.NewRDB(r)
+
+	tests := []struct {
+		registeredID string // ID for which cancel func is registered
+		publishID    string // ID to be published
+		wantCalled   bool   // whether cancel func should be called
+	}{
+		{"abc123", "abc123", true},
+		{"abc456", "abc123", false},
+	}
+
+	for _, tc := range tests {
+		called := false
+		fakeCancelFunc := func() {
+			called = true
+		}
+		cancelations := base.NewCancelations()
+		cancelations.Add(tc.registeredID, fakeCancelFunc)
+
+		subscriber := newSubscriber(rdbClient, cancelations)
+		subscriber.start()
+
+		if err := rdbClient.PublishCancelation(tc.publishID); err != nil {
+			subscriber.terminate()
+			t.Fatalf("could not publish cancelation message: %v", err)
+		}
+
+		// allow for redis to publish message
+		time.Sleep(time.Second)
+
+		if called != tc.wantCalled {
+			if tc.wantCalled {
+				t.Errorf("fakeCancelFunc was not called, want the function to be called")
+			} else {
+				t.Errorf("fakeCancelFunc was called, want the function to not be called")
+			}
+		}
+
+		subscriber.terminate()
+	}
+}

--- a/tools/asynqmon/cmd/cancel.go
+++ b/tools/asynqmon/cmd/cancel.go
@@ -1,0 +1,53 @@
+// Copyright 2020 Kentaro Hibino. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-redis/redis/v7"
+	"github.com/hibiken/asynq/internal/rdb"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// cancelCmd represents the cancel command
+var cancelCmd = &cobra.Command{
+	Use:   "cancel [task id]",
+	Short: "Sends a cancelation signal to the goroutine processing the specified task",
+	Long: `Cancel (asynqmon cancel) will send a cancelation signal to the goroutine processing 
+the specified task. 
+
+The command takes one argument which specifies the task to cancel.
+The task should be in in-progress state.
+Identifier for a task should be obtained by running "asynqmon ls" command.
+
+Handler implementation needs to be context aware for cancelation signal to
+actually cancel the processing.
+
+Example: asynqmon cancel bnogo8gt6toe23vhef0g`,
+	Args: cobra.ExactArgs(1),
+	Run:  cancel,
+}
+
+func init() {
+	rootCmd.AddCommand(cancelCmd)
+}
+
+func cancel(cmd *cobra.Command, args []string) {
+	r := rdb.NewRDB(redis.NewClient(&redis.Options{
+		Addr:     viper.GetString("uri"),
+		DB:       viper.GetInt("db"),
+		Password: viper.GetString("password"),
+	}))
+
+	err := r.PublishCancelation(args[0])
+	if err != nil {
+		fmt.Printf("could not send cancelation signal: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Successfully sent cancelation siganl for task %s\n", args[0])
+}


### PR DESCRIPTION
`asynqmon cancel [task ID]` will send a cancelation signal to the goroutine  processing the specified task. 

Handler implementation needs to be context aware in order to cancel command to stop the processing.