### PR TITLE
Share memory by communicating 👍

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"sync"
 	"time"
 
 	"github.com/hibiken/asynq/internal/base"
@@ -49,10 +50,12 @@ func (h *heartbeater) terminate() {
 	h.done <- struct{}{}
 }
 
-func (h *heartbeater) start() {
+func (h *heartbeater) start(wg *sync.WaitGroup) {
 	h.pinfo.Started = time.Now()
 	h.pinfo.State = "running"
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		h.beat()
 		timer := time.NewTimer(h.interval)
 		for {

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -34,8 +34,9 @@ func TestHeartbeater(t *testing.T) {
 	for _, tc := range tests {
 		h.FlushDB(t, r)
 
-		pi := base.NewProcessInfo(tc.host, tc.pid, tc.concurrency, tc.queues, false)
-		hb := newHeartbeater(rdbClient, pi, tc.interval)
+		stateCh := make(chan string)
+		workerCh := make(chan int)
+		hb := newHeartbeater(rdbClient, tc.host, tc.pid, tc.concurrency, tc.queues, false, tc.interval, stateCh, workerCh)
 
 		want := &base.ProcessInfo{
 			Host:        tc.host,
@@ -64,7 +65,7 @@ func TestHeartbeater(t *testing.T) {
 		}
 
 		// state change
-		pi.SetState("stopped")
+		stateCh <- "stopped"
 
 		// allow for heartbeater to write to redis
 		time.Sleep(tc.interval * 2)

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/hibiken/asynq/internal/rdb"
 )
 
+// FIXME: Make this test better.
 func TestHeartbeater(t *testing.T) {
 	r := setup(t)
 	rdbClient := rdb.NewRDB(r)
@@ -46,7 +48,8 @@ func TestHeartbeater(t *testing.T) {
 			Started:     time.Now(),
 			State:       "running",
 		}
-		hb.start()
+		var wg sync.WaitGroup
+		hb.start(&wg)
 
 		// allow for heartbeater to write to redis
 		time.Sleep(tc.interval * 2)

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -89,7 +89,6 @@ type TaskMessage struct {
 
 // ProcessInfo holds information about running background worker process.
 type ProcessInfo struct {
-	mu                sync.Mutex
 	Concurrency       int
 	Queues            map[string]int
 	StrictPriority    bool
@@ -109,27 +108,6 @@ func NewProcessInfo(host string, pid, concurrency int, queues map[string]int, st
 		Queues:         queues,
 		StrictPriority: strict,
 	}
-}
-
-// SetState set the state field of the process info.
-func (p *ProcessInfo) SetState(state string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.State = state
-}
-
-// SetStarted set the started field of the process info.
-func (p *ProcessInfo) SetStarted(t time.Time) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.Started = t
-}
-
-// IncrActiveWorkerCount increments active worker count by delta.
-func (p *ProcessInfo) IncrActiveWorkerCount(delta int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.ActiveWorkerCount += delta
 }
 
 // Cancelations is a collection that holds cancel functions for all in-progress tasks.

--- a/internal/base/base_test.go
+++ b/internal/base/base_test.go
@@ -5,7 +5,6 @@
 package base
 
 import (
-	"sync"
 	"testing"
 	"time"
 )
@@ -78,31 +77,4 @@ func TestProcessInfoKey(t *testing.T) {
 			t.Errorf("ProcessInfoKey(%s, %d) = %s, want %s", tc.hostname, tc.pid, got, tc.want)
 		}
 	}
-}
-
-// Note: Run this test with -race flag to check for data race.
-func TestProcessInfoSetter(t *testing.T) {
-	pi := NewProcessInfo("localhost", 1234, 8, map[string]int{"default": 1}, false)
-
-	var wg sync.WaitGroup
-
-	wg.Add(3)
-
-	go func() {
-		pi.SetState("runnning")
-		wg.Done()
-	}()
-
-	go func() {
-		pi.SetStarted(time.Now())
-		pi.IncrActiveWorkerCount(1)
-		wg.Done()
-	}()
-
-	go func() {
-		pi.SetState("stopped")
-		wg.Done()
-	}()
-
-	wg.Wait()
 }

--- a/processor.go
+++ b/processor.go
@@ -119,11 +119,13 @@ func (p *processor) terminate() {
 	p.restore() // move any unfinished tasks back to the queue.
 }
 
-func (p *processor) start() {
+func (p *processor) start(wg *sync.WaitGroup) {
 	// NOTE: The call to "restore" needs to complete before starting
 	// the processor goroutine.
 	p.restore()
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			select {
 			case <-p.done:

--- a/processor_test.go
+++ b/processor_test.go
@@ -72,7 +72,8 @@ func TestProcessorSuccess(t *testing.T) {
 		p := newProcessor(rdbClient, defaultQueueConfig, false, 10, defaultDelayFunc, nil, workerCh, cancelations)
 		p.handler = HandlerFunc(handler)
 
-		p.start()
+		var wg sync.WaitGroup
+		p.start(&wg)
 		for _, msg := range tc.incoming {
 			err := rdbClient.Enqueue(msg)
 			if err != nil {
@@ -159,7 +160,8 @@ func TestProcessorRetry(t *testing.T) {
 		p := newProcessor(rdbClient, defaultQueueConfig, false, 10, delayFunc, nil, workerCh, cancelations)
 		p.handler = HandlerFunc(handler)
 
-		p.start()
+		var wg sync.WaitGroup
+		p.start(&wg)
 		for _, msg := range tc.incoming {
 			err := rdbClient.Enqueue(msg)
 			if err != nil {
@@ -290,7 +292,8 @@ func TestProcessorWithStrictPriority(t *testing.T) {
 			defaultDelayFunc, nil, workerCh, cancelations)
 		p.handler = HandlerFunc(handler)
 
-		p.start()
+		var wg sync.WaitGroup
+		p.start(&wg)
 		time.Sleep(tc.wait)
 		p.terminate()
 		close(workerCh)

--- a/scheduler.go
+++ b/scheduler.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"sync"
 	"time"
 
 	"github.com/hibiken/asynq/internal/rdb"
@@ -43,8 +44,10 @@ func (s *scheduler) terminate() {
 }
 
 // start starts the "scheduler" goroutine.
-func (s *scheduler) start() {
+func (s *scheduler) start(wg *sync.WaitGroup) {
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			select {
 			case <-s.done:

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -69,7 +70,8 @@ func TestScheduler(t *testing.T) {
 		h.SeedRetryQueue(t, r, tc.initRetry)         // initialize retry queue
 		h.SeedEnqueuedQueue(t, r, tc.initQueue)      // initialize default queue
 
-		s.start()
+		var wg sync.WaitGroup
+		s.start(&wg)
 		time.Sleep(tc.wait)
 		s.terminate()
 

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -34,7 +35,8 @@ func TestSubscriber(t *testing.T) {
 		cancelations.Add(tc.registeredID, fakeCancelFunc)
 
 		subscriber := newSubscriber(rdbClient, cancelations)
-		subscriber.start()
+		var wg sync.WaitGroup
+		subscriber.start(&wg)
 
 		if err := rdbClient.PublishCancelation(tc.publishID); err != nil {
 			subscriber.terminate()

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -27,8 +27,11 @@ func TestSubscriber(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		var mu sync.Mutex
 		called := false
 		fakeCancelFunc := func() {
+			mu.Lock()
+			defer mu.Unlock()
 			called = true
 		}
 		cancelations := base.NewCancelations()
@@ -46,6 +49,7 @@ func TestSubscriber(t *testing.T) {
 		// allow for redis to publish message
 		time.Sleep(time.Second)
 
+		mu.Lock()
 		if called != tc.wantCalled {
 			if tc.wantCalled {
 				t.Errorf("fakeCancelFunc was not called, want the function to be called")
@@ -53,6 +57,7 @@ func TestSubscriber(t *testing.T) {
 				t.Errorf("fakeCancelFunc was called, want the function to not be called")
 			}
 		}
+		mu.Unlock()
 
 		subscriber.terminate()
 	}

--- a/syncer.go
+++ b/syncer.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"sync"
 	"time"
 )
 
@@ -39,8 +40,10 @@ func (s *syncer) terminate() {
 	s.done <- struct{}{}
 }
 
-func (s *syncer) start() {
+func (s *syncer) start(wg *sync.WaitGroup) {
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		var requests []*syncRequest
 		for {
 			select {

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -27,7 +28,8 @@ func TestSyncer(t *testing.T) {
 	const interval = time.Second
 	syncRequestCh := make(chan *syncRequest)
 	syncer := newSyncer(syncRequestCh, interval)
-	syncer.start()
+	var wg sync.WaitGroup
+	syncer.start(&wg)
 	defer syncer.terminate()
 
 	for _, msg := range inProgress {
@@ -66,7 +68,8 @@ func TestSyncerRetry(t *testing.T) {
 	const interval = time.Second
 	syncRequestCh := make(chan *syncRequest)
 	syncer := newSyncer(syncRequestCh, interval)
-	syncer.start()
+	var wg sync.WaitGroup
+	syncer.start(&wg)
 	defer syncer.terminate()
 
 	for _, msg := range inProgress {


### PR DESCRIPTION
Avoid the use of shared memory with mutex. 
Changes made:

- Confine `ProcessInfo` variable to the heartbeater goroutine
- Use channels to request for updates in the variable.