### PR TITLE
add support for custom redis logger

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 
+	stdlog "log"
+
 	"github.com/go-redis/redis/v7"
 )
 
@@ -204,6 +206,11 @@ func parseRedisSentinelURI(u *url.URL) (RedisConnOpt, error) {
 		password = v
 	}
 	return RedisFailoverClientOpt{MasterName: master, SentinelAddrs: addrs, Password: password}, nil
+}
+
+//SetReditLogger set redit logger
+func SetReditLogger(logger *stdlog.Logger) {
+	redis.SetLogger(logger)
 }
 
 // createRedisClient returns a redis client given a redis connection configuration.


### PR DESCRIPTION

Hello @hibiken, 
first of all, let me thank you for your great work :)

I'm using termui and asynq to simulate a worker and all the logs are redirected to logs files.
I don't know why, but go-redis print some logs direct to stdout / stderr.
because of this, when I got a redis error, my UI get broke.

![imagen](https://user-images.githubusercontent.com/5620128/106329996-3413e180-6261-11eb-8f3f-2265efe7e4ec.png)

go-redis comes with a function to define a global logger.
So I have added a wrapper function on asynq to be able to set that logger.

I did my test using the last version of asynq and I'm using logrus for logging.

To make some, just need to initialize a logrus instance and past it to the function.
```
cacheLogger := stdlog.New(jlog.Log.Writer(), "", 0)	
asynq.SetReditLogger(cacheLogger)
```

and the result was:
![imagen](https://user-images.githubusercontent.com/5620128/106330447-024f4a80-6262-11eb-96c6-e84f7fce2346.png)

this will also open an option to set a custom logger just for redis errors.
Maybe the logger could be part of the configuration like asynq does on server creation. I don't know.
Let me know if you have a better solution.

thanks!

