### PR TITLE
Run CI build with go1.16

### DIFF
--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
       - name: Benchmark
         run: go test -run=^$ -bench=. -count=5 -timeout=60m ./... | tee -a new.txt
       - name: Upload Benchmark

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.13.x, 1.14.x, 1.15.x, 1.16.x]
     runs-on: ${{ matrix.os }}
     services:
       redis:


### PR DESCRIPTION
- Add go1.16 to build matrix
- Run benchstat workflow with go1.16