### PR TITLE
client.Enqueue - prevent empty task typename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Client.Enqueue` no longer enqueues tasks with empty typename; Error message is returned.
+
 ## [0.18.2] - 2020-07-15
 
 ### Changed

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ package asynq
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -178,8 +179,8 @@ func (d processInOption) Value() interface{} { return time.Duration(d) }
 // ErrDuplicateTask error only applies to tasks enqueued with a Unique option.
 var ErrDuplicateTask = errors.New("task already exists")
 
-// ErrEmptyTypeTask indicates that task's typename is not specified.
-var ErrEmptyTypeTask = errors.New("task typename not specified")
+// ErrEmptyTypename indicates that task's typename is empty.
+var ErrEmptyTypename = errors.New("task typename cannot be empty")
 
 type option struct {
 	retry     int
@@ -269,8 +270,8 @@ func (c *Client) Close() error {
 //
 // If no ProcessAt or ProcessIn options are provided, the task will be pending immediately.
 func (c *Client) Enqueue(task *Task, opts ...Option) (*TaskInfo, error) {
-	if task.Type() == "" {
-		return nil, fmt.Errorf("%w", ErrEmptyTypeTask)
+	if strings.TrimSpace(task.Type()) == "" {
+		return nil, fmt.Errorf("%w", ErrEmptyTypename)
 	}
 	c.mu.Lock()
 	if defaults, ok := c.opts[task.Type()]; ok {

--- a/client.go
+++ b/client.go
@@ -178,6 +178,9 @@ func (d processInOption) Value() interface{} { return time.Duration(d) }
 // ErrDuplicateTask error only applies to tasks enqueued with a Unique option.
 var ErrDuplicateTask = errors.New("task already exists")
 
+// ErrEmptyTypeTask indicates that task's typename is not specified.
+var ErrEmptyTypeTask = errors.New("task typename not specified")
+
 type option struct {
 	retry     int
 	queue     string
@@ -266,6 +269,9 @@ func (c *Client) Close() error {
 //
 // If no ProcessAt or ProcessIn options are provided, the task will be pending immediately.
 func (c *Client) Enqueue(task *Task, opts ...Option) (*TaskInfo, error) {
+	if task.Type() == "" {
+		return nil, fmt.Errorf("%w", ErrEmptyTypeTask)
+	}
 	c.mu.Lock()
 	if defaults, ok := c.opts[task.Type()]; ok {
 		opts = append(defaults, opts...)

--- a/client.go
+++ b/client.go
@@ -179,9 +179,6 @@ func (d processInOption) Value() interface{} { return time.Duration(d) }
 // ErrDuplicateTask error only applies to tasks enqueued with a Unique option.
 var ErrDuplicateTask = errors.New("task already exists")
 
-// ErrEmptyTypename indicates that task's typename is empty.
-var ErrEmptyTypename = errors.New("task typename cannot be empty")
-
 type option struct {
 	retry     int
 	queue     string
@@ -271,7 +268,7 @@ func (c *Client) Close() error {
 // If no ProcessAt or ProcessIn options are provided, the task will be pending immediately.
 func (c *Client) Enqueue(task *Task, opts ...Option) (*TaskInfo, error) {
 	if strings.TrimSpace(task.Type()) == "" {
-		return nil, fmt.Errorf("%w", ErrEmptyTypename)
+		return nil, fmt.Errorf("task typename cannot be empty")
 	}
 	c.mu.Lock()
 	if defaults, ok := c.opts[task.Type()]; ok {

--- a/client_test.go
+++ b/client_test.go
@@ -590,6 +590,11 @@ func TestClientEnqueueError(t *testing.T) {
 			task: NewTask("", h.JSON(map[string]interface{}{})),
 			opts: []Option{},
 		},
+		{
+			desc: "With blank task typename",
+			task: NewTask("    ", h.JSON(map[string]interface{}{})),
+			opts: []Option{},
+		},
 	}
 
 	for _, tc := range tests {

--- a/client_test.go
+++ b/client_test.go
@@ -585,6 +585,11 @@ func TestClientEnqueueError(t *testing.T) {
 				Queue(""),
 			},
 		},
+		{
+			desc: "With empty task typename",
+			task: NewTask("", h.JSON(map[string]interface{}{})),
+			opts: []Option{},
+		},
 	}
 
 	for _, tc := range tests {

--- a/servemux.go
+++ b/servemux.go
@@ -98,7 +98,7 @@ func (mux *ServeMux) Handle(pattern string, handler Handler) {
 	mux.mu.Lock()
 	defer mux.mu.Unlock()
 
-	if pattern == "" {
+	if strings.TrimSpace(pattern) == "" {
 		panic("asynq: invalid pattern")
 	}
 	if handler == nil {


### PR DESCRIPTION
Hi @hibiken! Thanks for this library and sharing your work 👍 

When I was trying to get familiar with the code base and test out some of the features locally I also decided to contribute and help a little bit. I picked #297 as something that appears easy to start with. Please let me know if I missed something out or the solution should be improved/adjusted. Keep in mind that currently you're still able to queue and consume tasks with typenames like `" "` (just a single whitespace). This can be a feature but maybe also should be handled differently?

Thanks again and I'm looking forward to contribute in future!

