### PR TITLE
fix: missing import statement in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ package tasks
 
 import (
     "fmt"
-
+    "encoding/json"
     "github.com/hibiken/asynq"
 )
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ Next, write a package that encapsulates task creation and task handling.
 package tasks
 
 import (
-    "fmt"
+    "context"
     "encoding/json"
+    "fmt"
+    "log"
+    "time"
     "github.com/hibiken/asynq"
 )
 


### PR DESCRIPTION
Just a quick fix.

I noticed a few imports are missing in the example code in the README
