### PR TITLE
Add support for deriving `context` for TaskHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2022-01-29
+
+### Added
+
+- `BaseContext` introduced in `Config` to specify callback hook to provide a base `context` from which `Handler` `context` is derived
+
 ## [0.21.0] - 2022-01-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.22.0] - 2022-01-29
-
 ### Added
 
-- `BaseContext` introduced in `Config` to specify callback hook to provide a base `context` from which `Handler` `context` is derived
+- `BaseContext` is introduced in `Config` to specify callback hook to provide a base `context` from which `Handler` `context` is derived
 
 ## [0.21.0] - 2022-01-22
 

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hibiken/asynq/internal/base"
 )
 
-type BaseContext func() context.Context
-
 // A taskMetadata holds task scoped data to put in context.
 type taskMetadata struct {
 	id         string
@@ -37,7 +35,7 @@ func New(base context.Context, msg *base.TaskMessage, deadline time.Time) (conte
 		retryCount: msg.Retried,
 		qname:      msg.Queue,
 	}
-	ctx := context.WithValue(context.Background(), metadataCtxKey, metadata)
+	ctx := context.WithValue(base, metadataCtxKey, metadata)
 	return context.WithDeadline(ctx, deadline)
 }
 

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hibiken/asynq/internal/base"
 )
 
+type BaseContext func() context.Context
+
 // A taskMetadata holds task scoped data to put in context.
 type taskMetadata struct {
 	id         string
@@ -28,7 +30,7 @@ type ctxKey int
 const metadataCtxKey ctxKey = 0
 
 // New returns a context and cancel function for a given task message.
-func New(msg *base.TaskMessage, deadline time.Time) (context.Context, context.CancelFunc) {
+func New(base context.Context, msg *base.TaskMessage, deadline time.Time) (context.Context, context.CancelFunc) {
 	metadata := taskMetadata{
 		id:         msg.ID,
 		maxRetry:   msg.Retry,

--- a/processor.go
+++ b/processor.go
@@ -27,7 +27,7 @@ type processor struct {
 	broker base.Broker
 
 	handler   Handler
-	baseCtxFn BaseCtxFn
+	baseCtxFn func() context.Context
 
 	queueConfig map[string]int
 
@@ -72,7 +72,7 @@ type processor struct {
 type processorParams struct {
 	logger          *log.Logger
 	broker          base.Broker
-	baseCtxFn       BaseCtxFn
+	baseCtxFn       func() context.Context
 	retryDelayFunc  RetryDelayFunc
 	isFailureFunc   func(error) bool
 	syncCh          chan<- *syncRequest

--- a/processor.go
+++ b/processor.go
@@ -26,8 +26,8 @@ type processor struct {
 	logger *log.Logger
 	broker base.Broker
 
-	handler       Handler
-	baseContextFn asynqcontext.BaseContext
+	handler   Handler
+	baseCtxFn BaseCtxFn
 
 	queueConfig map[string]int
 
@@ -72,7 +72,7 @@ type processor struct {
 type processorParams struct {
 	logger          *log.Logger
 	broker          base.Broker
-	baseCtxFn       asynqcontext.BaseContext
+	baseCtxFn       BaseCtxFn
 	retryDelayFunc  RetryDelayFunc
 	isFailureFunc   func(error) bool
 	syncCh          chan<- *syncRequest
@@ -96,7 +96,7 @@ func newProcessor(params processorParams) *processor {
 	return &processor{
 		logger:          params.logger,
 		broker:          params.broker,
-		baseContextFn:   params.baseCtxFn,
+		baseCtxFn:       params.baseCtxFn,
 		queueConfig:     queues,
 		orderedQueues:   orderedQueues,
 		retryDelayFunc:  params.retryDelayFunc,
@@ -193,7 +193,7 @@ func (p *processor) exec() {
 				<-p.sema // release token
 			}()
 
-			ctx, cancel := asynqcontext.New(p.baseContextFn(), msg, deadline)
+			ctx, cancel := asynqcontext.New(p.baseCtxFn(), msg, deadline)
 			p.cancelations.Add(msg.ID, cancel)
 			defer func() {
 				cancel()

--- a/server.go
+++ b/server.go
@@ -101,10 +101,7 @@ type Config struct {
 	//
 	// If BaseContext is nil, the default is context.Background().
 	// If this is defined, then it MUST return a non-nil context
-	BaseContext BaseCtxFn
-
-	// SleepOnEmptyQueue optionally specifies the amount of time to wait before polling again when there are no messages in the queue
-	SleepOnEmptyQueue time.Duration
+	BaseContext func() context.Context
 
 	// Function to calculate retry delay for a failed task.
 	//
@@ -211,9 +208,6 @@ type ErrorHandlerFunc func(ctx context.Context, task *Task, err error)
 func (fn ErrorHandlerFunc) HandleError(ctx context.Context, task *Task, err error) {
 	fn(ctx, task, err)
 }
-
-// BaseCtxFn provides the root context from where the execution contexts of tasks are derived
-type BaseCtxFn func() context.Context
 
 // RetryDelayFunc calculates the retry delay duration for a failed task given
 // the retry count, error, and the task.

--- a/server.go
+++ b/server.go
@@ -97,10 +97,11 @@ type Config struct {
 	// to the number of CPUs usable by the current process.
 	Concurrency int
 
-	// BaseContext optionally specifies a function that returns
-	// the base context for invocations on this server.
+	// BaseContext optionally specifies a function that returns the base context for Handler invocations on this server.
+	//
 	// If BaseContext is nil, the default is context.Background().
-	BaseContext func() context.Context
+	// If this is defined, then it MUST return a non-nil context
+	BaseContext BaseCtxFn
 
 	// SleepOnEmptyQueue optionally specifies the amount of time to wait before polling again when there are no messages in the queue
 	SleepOnEmptyQueue time.Duration
@@ -210,6 +211,9 @@ type ErrorHandlerFunc func(ctx context.Context, task *Task, err error)
 func (fn ErrorHandlerFunc) HandleError(ctx context.Context, task *Task, err error) {
 	fn(ctx, task, err)
 }
+
+// BaseCtxFn provides the root context from where the execution contexts of tasks are derived
+type BaseCtxFn func() context.Context
 
 // RetryDelayFunc calculates the retry delay duration for a failed task given
 // the retry count, error, and the task.


### PR DESCRIPTION
@hibiken: For #381 , I wrote up a reference implementation for deriving contexts for task handlers. Not sure if this follows your code conventions. Let me know what changes you need to meet `asynq` standards