### PR TITLE
options: add task option for unlimited retry

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,6 +88,11 @@ func MaxRetry(n int) Option {
 	return retryOption(n)
 }
 
+// UnlimitedRetry returns an option to specify the task will be retried indefinitely.
+func UnlimitedRetry() Option {
+	return retryOption(unlimitedRetry)
+}
+
 func (n retryOption) String() string     { return fmt.Sprintf("MaxRetry(%d)", int(n)) }
 func (n retryOption) Type() OptionType   { return MaxRetryOpt }
 func (n retryOption) Value() interface{} { return int(n) }
@@ -297,6 +302,8 @@ const (
 
 	// Default timeout used if both timeout and deadline are not specified.
 	defaultTimeout = 30 * time.Minute
+
+	unlimitedRetry = -1
 )
 
 // Value zero indicates no timeout and no deadline.

--- a/processor.go
+++ b/processor.go
@@ -330,7 +330,7 @@ func (p *processor) handleFailedMessage(ctx context.Context, l *base.Lease, msg 
 		p.retry(l, msg, err, false /*isFailure*/)
 		return
 	}
-	if msg.Retried >= msg.Retry || errors.Is(err, SkipRetry) {
+	if (msg.Retried >= msg.Retry && msg.Retry != unlimitedRetry) || errors.Is(err, SkipRetry) {
 		p.logger.Warnf("Retry exhausted for task id=%s", msg.ID)
 		p.archive(l, msg, err)
 	} else {

--- a/tools/asynq/cmd/dash/draw.go
+++ b/tools/asynq/cmd/dash/draw.go
@@ -290,7 +290,7 @@ var activeTaskTableColumns = []*columnConfig[*asynq.TaskInfo]{
 	{"ID", alignLeft, func(t *asynq.TaskInfo) string { return t.ID }},
 	{"Type", alignLeft, func(t *asynq.TaskInfo) string { return t.Type }},
 	{"Retried", alignRight, func(t *asynq.TaskInfo) string { return strconv.Itoa(t.Retried) }},
-	{"Max Retry", alignRight, func(t *asynq.TaskInfo) string { return strconv.Itoa(t.MaxRetry) }},
+	{"Max Retry", alignRight, func(t *asynq.TaskInfo) string { return formatMaxRetry(t.MaxRetry) }},
 	{"Payload", alignLeft, func(t *asynq.TaskInfo) string { return formatByteSlice(t.Payload) }},
 }
 
@@ -298,7 +298,7 @@ var pendingTaskTableColumns = []*columnConfig[*asynq.TaskInfo]{
 	{"ID", alignLeft, func(t *asynq.TaskInfo) string { return t.ID }},
 	{"Type", alignLeft, func(t *asynq.TaskInfo) string { return t.Type }},
 	{"Retried", alignRight, func(t *asynq.TaskInfo) string { return strconv.Itoa(t.Retried) }},
-	{"Max Retry", alignRight, func(t *asynq.TaskInfo) string { return strconv.Itoa(t.MaxRetry) }},
+	{"Max Retry", alignRight, func(t *asynq.TaskInfo) string { return formatMaxRetry(t.MaxRetry) }},
 	{"Payload", alignLeft, func(t *asynq.TaskInfo) string { return formatByteSlice(t.Payload) }},
 }
 
@@ -596,6 +596,17 @@ func formatByteSlice(data []byte) string {
 		return "<non-printable>"
 	}
 	return strings.ReplaceAll(string(data), "\n", "  ")
+}
+
+const optionUnlimitedRetry = -1
+
+// formatMaxRetry is used to display the number of allowed retries or unlimited if configured with -1.
+// TODO: this is redefined in ../task.go and should be consolidated
+func formatMaxRetry(maxRetry int) string {
+	if maxRetry == optionUnlimitedRetry {
+		return "unlimited"
+	}
+	return strconv.Itoa(maxRetry)
 }
 
 type modalRowDrawer struct {

--- a/tools/asynq/cmd/task.go
+++ b/tools/asynq/cmd/task.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -323,7 +324,7 @@ func listRetryTasks(qname string, pageNum, pageSize int) {
 		func(w io.Writer, tmpl string) {
 			for _, t := range tasks {
 				fmt.Fprintf(w, tmpl, t.ID, t.Type, sprintBytes(t.Payload), formatProcessAt(t.NextProcessAt),
-					t.LastErr, formatPastTime(t.LastFailedAt), t.Retried, t.MaxRetry)
+					t.LastErr, formatPastTime(t.LastFailedAt), t.Retried, formatMaxRetry(t.MaxRetry))
 			}
 		},
 	)
@@ -429,7 +430,7 @@ func printTaskInfo(info *asynq.TaskInfo) {
 	fmt.Printf("ID:      %s\n", info.ID)
 	fmt.Printf("Type:    %s\n", info.Type)
 	fmt.Printf("State:   %v\n", info.State)
-	fmt.Printf("Retried: %d/%d\n", info.Retried, info.MaxRetry)
+	fmt.Printf("Retried: %d/%s\n", info.Retried, formatMaxRetry(info.MaxRetry))
 	fmt.Println()
 	fmt.Printf("Next process time: %s\n", formatNextProcessAt(info.NextProcessAt))
 	if len(info.LastErr) != 0 {
@@ -456,6 +457,17 @@ func formatPastTime(t time.Time) string {
 		return ""
 	}
 	return t.Format(time.UnixDate)
+}
+
+const optionUnlimitedRetry = -1
+
+// formatMaxRetry is used to display the number of allowed retries or unlimited if configured with -1.
+// TODO: this is redefined in ./dash/draw.go and should be consolidated
+func formatMaxRetry(maxRetry int) string {
+	if maxRetry == optionUnlimitedRetry {
+		return "unlimited"
+	}
+	return strconv.Itoa(maxRetry)
 }
 
 func taskArchive(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This adds an `UnlimitedRetry()` option that can be used to extend retries indefinitely on a given task if needed.  This would be nice in our system for a subset of tasks we truly don't want to go to archive - it is a bit more direct to test than other current approaches.  I got a good degree of confidence from the unit tests but verified w the following:

```
func main() {
	opt := asynq.RedisClientOpt{Addr: "localhost:6379", DB: 8}
	srv := asynq.NewServer(
		opt,
		asynq.Config{
			RetryDelayFunc: func(n int, e error, t *asynq.Task) time.Duration {
				return 1 * time.Millisecond
			},
		},
	)

	sampleType := "sample-task"

	go func() {
		time.Sleep(1 * time.Second)
		ct := asynq.NewClient(opt)
		_, _ = ct.Enqueue(asynq.NewTask(sampleType, []byte("task with default retries %v\n")))
		_, _ = ct.Enqueue(asynq.NewTask(sampleType, []byte("task with unlimited retries %v\n")), asynq.UnlimitedRetry())
	}()

	mux := asynq.NewServeMux()
	mux.HandleFunc(sampleType, func(ctx context.Context, task *asynq.Task) error {
		f := string(task.Payload())
		rc, _ := asynq.GetRetryCount(ctx)
		fmt.Printf(f, rc)

		if rc > 30 {
			return asynq.SkipRetry
		}
		return fmt.Errorf("force retry check %d", rc+1)
	})

	if err := srv.Run(mux); err != nil {
		log.Fatalf("could not run server: %v", err)
	}
}
```

