### PR TITLE
feat: add custom unique key option

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1176,3 +1176,46 @@ func TestClientEnqueueUniqueWithProcessAtOption(t *testing.T) {
 		}
 	}
 }
+
+func TestClientEnqueueUniqueWithUniqueKeyOption(t *testing.T) {
+	r := setup(t)
+	c := NewClient(getRedisConnOpt(t))
+	defer c.Close()
+
+	tests := []struct {
+		task *Task
+		ttl  time.Duration
+	}{
+		{
+			NewTask("email", h.JSON(map[string]interface{}{"user_id": 123})),
+			time.Hour,
+		},
+	}
+
+	for _, tc := range tests {
+		h.FlushDB(t, r) // clean up db before each test case.
+
+		// Enqueue the task first. It should succeed.
+		_, err := c.Enqueue(tc.task, Unique(tc.ttl), UniqueKey("custom_unique_key"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		gotTTL := r.TTL(context.Background(), base.CustomUniqueKey(base.DefaultQueueName, tc.task.Type(), "custom_unique_key")).Val()
+		if !cmp.Equal(tc.ttl.Seconds(), gotTTL.Seconds(), cmpopts.EquateApprox(0, 1)) {
+			t.Errorf("TTL = %v, want %v", gotTTL, tc.ttl)
+			continue
+		}
+
+		// Enqueue the task again. It should fail.
+		_, err = c.Enqueue(tc.task, Unique(tc.ttl), UniqueKey("custom_unique_key"))
+		if err == nil {
+			t.Errorf("Enqueueing %+v did not return an error", tc.task)
+			continue
+		}
+		if !errors.Is(err, ErrDuplicateTask) {
+			t.Errorf("Enqueueing %+v returned an error that is not ErrDuplicateTask", tc.task)
+			continue
+		}
+	}
+}

--- a/inspector.go
+++ b/inspector.go
@@ -945,6 +945,12 @@ func parseOption(s string) (Option, error) {
 			return nil, err
 		}
 		return Unique(d), nil
+	case "UniqueKey":
+		key, err := strconv.Unquote(arg)
+		if err != nil {
+			return nil, err
+		}
+		return UniqueKey(key), nil
 	case "ProcessAt":
 		t, err := time.Parse(time.UnixDate, arg)
 		if err != nil {

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -205,6 +205,12 @@ func UniqueKey(qname, tasktype string, payload []byte) string {
 	return fmt.Sprintf("%sunique:%s:%s", QueueKeyPrefix(qname), tasktype, hex.EncodeToString(checksum[:]))
 }
 
+// CustomUniqueKey returns a redis key with the given type, custom key, and queue name.
+func CustomUniqueKey(qname, tasktype string, customKey string) string {
+	checksum := md5.Sum([]byte(customKey))
+	return fmt.Sprintf("%sunique:%s:%s", QueueKeyPrefix(qname), tasktype, hex.EncodeToString(checksum[:]))
+}
+
 // GroupKeyPrefix returns a prefix for group key.
 func GroupKeyPrefix(qname string) string {
 	return fmt.Sprintf("%sg:", QueueKeyPrefix(qname))


### PR DESCRIPTION
When Enqueue Unique Task, allow the user to customize the UniqueKey instead of using Task Payload by default, because the payload may contain things like trace IDs from upstream, and in some scenarios these tasks should still be considered the same task despite the differences in these fields.

The reason for not using task ID is that TTL is needed to avoid some workers quitting abnormally, making it impossible to continue the task.