### PR TITLE
fix redis sentinel url parse

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -519,7 +519,7 @@ func parseRedisSentinelURI(u *url.URL) (RedisConnOpt, error) {
 	if v, ok := u.User.Password(); ok {
 		password = v
 	}
-	return RedisFailoverClientOpt{MasterName: master, SentinelAddrs: addrs, Password: password}, nil
+	return RedisFailoverClientOpt{MasterName: master, SentinelAddrs: addrs, SentinelPassword: password}, nil
 }
 
 // ResultWriter is a client interface to write result data for a task.

--- a/asynq_test.go
+++ b/asynq_test.go
@@ -143,9 +143,9 @@ func TestParseRedisURI(t *testing.T) {
 		{
 			"redis-sentinel://:mypassword@localhost:5000,localhost:5001,localhost:5002?master=mymaster",
 			RedisFailoverClientOpt{
-				MasterName:    "mymaster",
-				SentinelAddrs: []string{"localhost:5000", "localhost:5001", "localhost:5002"},
-				Password:      "mypassword",
+				MasterName:       "mymaster",
+				SentinelAddrs:    []string{"localhost:5000", "localhost:5001", "localhost:5002"},
+				SentinelPassword: "mypassword",
 			},
 		},
 	}


### PR DESCRIPTION
It is actually using SentinelPassword to do sentinel authentication, see from the code
![image](https://user-images.githubusercontent.com/1894696/189259785-d0822d45-ffb2-4136-9d2c-9a1852f915c9.png)
If we set Password from url instead of setting SentinelPassword, we will meet such error
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/1894696/189259700-38148d9d-3208-42e0-920c-236f6664cc92.png">
