### PR TITLE
Improve performance of enqueueing tasks

### DIFF
--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -160,6 +160,54 @@ func TestEnqueueTaskIdConflictError(t *testing.T) {
 	}
 }
 
+func TestEnqueueQueueCache(t *testing.T) {
+	r := setup(t)
+	defer r.Close()
+	t1 := h.NewTaskMessageWithQueue("sync1", nil, "low")
+	t2 := h.NewTaskMessageWithQueue("sync2", nil, "low")
+
+	enqueueTime := time.Now()
+	clock := timeutil.NewSimulatedClock(enqueueTime)
+	r.SetClock(clock)
+
+	err := r.Enqueue(context.Background(), t1)
+	if err != nil {
+		t.Fatalf("(*RDB).Enqueue(msg) = %v, want nil", err)
+	}
+
+	// Check queue is in the AllQueues set.
+	if !r.client.SIsMember(context.Background(), base.AllQueues, t1.Queue).Val() {
+		t.Fatalf("%q is not a member of SET %q", t1.Queue, base.AllQueues)
+	}
+
+	if _, ok := r.queuesCache[t1.Queue]; !ok {
+		t.Fatalf("%q is not cached in %v", t1.Queue, r.queuesCache)
+	}
+
+	// Move clock to ensure cache is expired
+	clock.AdvanceTime(15 * time.Second)
+
+	// Delete queue from AllQueues set to ensure it will be re-added
+	err = r.client.SRem(context.Background(), base.AllQueues, "low").Err()
+	if err != nil {
+		t.Fatalf("Redis SREM = %v, want nil", err)
+	}
+
+	err = r.Enqueue(context.Background(), t2)
+	if err != nil {
+		t.Fatalf("(*RDB).Enqueue(msg) = %v, want nil", err)
+	}
+
+	if !r.client.SIsMember(context.Background(), base.AllQueues, t2.Queue).Val() {
+		t.Fatalf("%q is not a member of SET %q", t2.Queue, base.AllQueues)
+	}
+
+	// Should be cached again
+	if expiration := r.queuesCache[t2.Queue]; expiration.Before(clock.Now()) {
+		t.Fatalf("%q cache is too old %v", t2.Queue, expiration)
+	}
+}
+
 func TestEnqueueUnique(t *testing.T) {
 	r := setup(t)
 	defer r.Close()


### PR DESCRIPTION
Shows a potential solution to #549 

Create a map of queue names -> expiration dates in the RDB client. Every time we enqueue a task to queue X, cache queue X in the map and expire it after 10 secs. A mutex is used to protect the access, but there isn't a concern of lock contention as the clients will spend most of their time issuing network calls to enqueue tasks, and acquiring locks to check expiration is very fast. 

The issue highlights the performance improvements but will re-post them here as well
|                                   | Before        | After     |
| ---                             |    ----         |          --- |
| Producer CPU          | 195 mcores             | 173 mcores   |
| Redis CPU                | 290 ms            | 222 ms      |
| Redis cmds/sec       | 8300            |  6600      |

All deployments were done in a normal k8s environment and metrics were measured through Datadog

Caveat: 
This approach keeps the in-memory map of queues forever. It doesn't delete the entry when it expires. This is much simpler to implement, but if there is an app that enqueues tasks to millions of randomly named queues and the app never gets restarted, there is a potential memory leak. However that seems to be an unlikely use case of this library. 