### PR TITLE
Add StateChanged to watch state updates

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -139,6 +139,15 @@ func fromUnixTimeOrZero(t int64) time.Time {
 	return time.Unix(t, 0)
 }
 
+// TaskDetail transform inner base.Taskinfo into TaskInfo
+func TaskDetail(task interface{}) *TaskInfo {
+	bti := task.(*base.TaskInfo)
+	if bti == nil {
+		return nil
+	}
+	return newTaskInfo(bti.Message, bti.State, bti.NextProcessAt, bti.Result)
+}
+
 func newTaskInfo(msg *base.TaskMessage, state base.TaskState, nextProcessAt time.Time, result []byte) *TaskInfo {
 	info := TaskInfo{
 		ID:            msg.ID,
@@ -438,10 +447,11 @@ func (opt RedisClusterClientOpt) MakeRedisClient() interface{} {
 //
 // Three URI schemes are supported, which are redis:, rediss:, redis-socket:, and redis-sentinel:.
 // Supported formats are:
-//     redis://[:password@]host[:port][/dbnumber]
-//     rediss://[:password@]host[:port][/dbnumber]
-//     redis-socket://[:password@]path[?db=dbnumber]
-//     redis-sentinel://[:password@]host1[:port][,host2:[:port]][,hostN:[:port]][?master=masterName]
+//
+//	redis://[:password@]host[:port][/dbnumber]
+//	rediss://[:password@]host[:port][/dbnumber]
+//	redis-socket://[:password@]path[?db=dbnumber]
+//	redis-sentinel://[:password@]host1[:port][,host2:[:port]][,hostN:[:port]][?master=masterName]
 func ParseRedisURI(uri string) (RedisConnOpt, error) {
 	u, err := url.Parse(uri)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -150,9 +150,9 @@ func (t deadlineOption) Value() interface{} { return time.Time(t) }
 // TTL duration must be greater than or equal to 1 second.
 //
 // Uniqueness of a task is based on the following properties:
-//     - Task Type
-//     - Task Payload
-//     - Queue Name
+//   - Task Type
+//   - Task Payload
+//   - Queue Name
 func Unique(ttl time.Duration) Option {
 	return uniqueOption(ttl)
 }
@@ -425,4 +425,9 @@ func (c *Client) addToGroup(ctx context.Context, msg *base.TaskMessage, group st
 		return c.broker.AddToGroupUnique(ctx, msg, group, uniqueTTL)
 	}
 	return c.broker.AddToGroup(ctx, msg, group)
+}
+
+// StateChanged watchs state updates, with more customized detail
+func (c *Client) StateChanged(handler func(map[string]interface{}), more ...string) error {
+	return c.broker.StateChanged(handler, more...)
 }

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -752,4 +752,7 @@ type Broker interface {
 	PublishCancelation(id string) error
 
 	WriteResult(qname, id string, data []byte) (n int, err error)
+
+	// StateChanged watch state updates, with more customized detail
+	StateChanged(handler func(map[string]interface{}), more ...string) error
 }

--- a/server.go
+++ b/server.go
@@ -697,3 +697,8 @@ func (srv *Server) Stop() {
 	srv.processor.stop()
 	srv.logger.Info("Processor stopped")
 }
+
+// StateChanged watch state updates, with more customized detail
+func (srv *Server) StateChanged(handler func(map[string]interface{}), more ...string) error {
+	return srv.broker.StateChanged(handler, more...)
+}


### PR DESCRIPTION
implement StateChanged(func(map[string]interface{}), more ...string) for both client and server, to watch state updates with more customized detail, e.g. "completed:result" as default,
e.g. pending:next|task|result