### PR TITLE
Add interface for Inspector methods

### DIFF
--- a/inspector.go
+++ b/inspector.go
@@ -19,7 +19,7 @@ import (
 // Inspector is a client interface to inspect and mutate the state of
 // queues and tasks.
 type Inspector struct {
-	rdb *rdb.RDB
+	rdb base.QueueInspector
 }
 
 // New returns a new instance of Inspector.
@@ -304,7 +304,7 @@ func (i *Inspector) ListPendingTasks(queue string, opts ...ListOption) ([]*TaskI
 		return nil, fmt.Errorf("asynq: %v", err)
 	}
 	opt := composeListOptions(opts...)
-	pgn := rdb.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
+	pgn := base.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
 	infos, err := i.rdb.ListPending(queue, pgn)
 	switch {
 	case errors.IsQueueNotFound(err):
@@ -332,7 +332,7 @@ func (i *Inspector) ListActiveTasks(queue string, opts ...ListOption) ([]*TaskIn
 		return nil, fmt.Errorf("asynq: %v", err)
 	}
 	opt := composeListOptions(opts...)
-	pgn := rdb.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
+	pgn := base.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
 	infos, err := i.rdb.ListActive(queue, pgn)
 	switch {
 	case errors.IsQueueNotFound(err):
@@ -372,7 +372,7 @@ func (i *Inspector) ListAggregatingTasks(queue, group string, opts ...ListOption
 		return nil, fmt.Errorf("asynq: %v", err)
 	}
 	opt := composeListOptions(opts...)
-	pgn := rdb.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
+	pgn := base.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
 	infos, err := i.rdb.ListAggregating(queue, group, pgn)
 	switch {
 	case errors.IsQueueNotFound(err):
@@ -401,7 +401,7 @@ func (i *Inspector) ListScheduledTasks(queue string, opts ...ListOption) ([]*Tas
 		return nil, fmt.Errorf("asynq: %v", err)
 	}
 	opt := composeListOptions(opts...)
-	pgn := rdb.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
+	pgn := base.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
 	infos, err := i.rdb.ListScheduled(queue, pgn)
 	switch {
 	case errors.IsQueueNotFound(err):
@@ -430,7 +430,7 @@ func (i *Inspector) ListRetryTasks(queue string, opts ...ListOption) ([]*TaskInf
 		return nil, fmt.Errorf("asynq: %v", err)
 	}
 	opt := composeListOptions(opts...)
-	pgn := rdb.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
+	pgn := base.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
 	infos, err := i.rdb.ListRetry(queue, pgn)
 	switch {
 	case errors.IsQueueNotFound(err):
@@ -459,7 +459,7 @@ func (i *Inspector) ListArchivedTasks(queue string, opts ...ListOption) ([]*Task
 		return nil, fmt.Errorf("asynq: %v", err)
 	}
 	opt := composeListOptions(opts...)
-	pgn := rdb.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
+	pgn := base.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
 	infos, err := i.rdb.ListArchived(queue, pgn)
 	switch {
 	case errors.IsQueueNotFound(err):
@@ -488,7 +488,7 @@ func (i *Inspector) ListCompletedTasks(queue string, opts ...ListOption) ([]*Tas
 		return nil, fmt.Errorf("asynq: %v", err)
 	}
 	opt := composeListOptions(opts...)
-	pgn := rdb.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
+	pgn := base.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
 	infos, err := i.rdb.ListCompleted(queue, pgn)
 	switch {
 	case errors.IsQueueNotFound(err):
@@ -998,7 +998,7 @@ type SchedulerEnqueueEvent struct {
 // By default, it retrieves the first 30 tasks.
 func (i *Inspector) ListSchedulerEnqueueEvents(entryID string, opts ...ListOption) ([]*SchedulerEnqueueEvent, error) {
 	opt := composeListOptions(opts...)
-	pgn := rdb.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
+	pgn := base.Pagination{Size: opt.pageSize, Page: opt.pageNum - 1}
 	data, err := i.rdb.ListSchedulerEnqueueEvents(entryID, pgn)
 	if err != nil {
 		return nil, err

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -777,6 +777,11 @@ func (p Pagination) Stop() int64 {
 // See rdb.RDB as a reference implementation.
 type QueueInspector interface {
 	Close() error
+	// SetClock sets the clock used by RDB to the given clock.
+	// Use this function to set the clock to SimulatedClock in tests.
+	SetClock(c timeutil.Clock)
+
+	PublishCancelation(id string) error
 
 	// Describe task and queues
 	AllQueues() ([]string, error)
@@ -788,6 +793,7 @@ type QueueInspector interface {
 	ListArchived(qname string, pgn Pagination) ([]*TaskInfo, error)
 	ListCompleted(qname string, pgn Pagination) ([]*TaskInfo, error)
 	ListAggregating(qname, gname string, pgn Pagination) ([]*TaskInfo, error)
+	ListLeaseExpired(cutoff time.Time, qnames ...string) ([]*TaskMessage, error)
 
 	//Scheduler info
 	ListSchedulerEntries() ([]*SchedulerEntry, error)

--- a/internal/base/stats.go
+++ b/internal/base/stats.go
@@ -1,0 +1,67 @@
+package base
+
+import "time"
+
+type GroupStat struct {
+	// Name of the group.
+	Group string
+
+	// Size of the group.
+	Size int
+}
+
+// Stats represents a state of queues at a certain time.
+type Stats struct {
+	// Name of the queue (e.g. "default", "critical").
+	Queue string
+	// MemoryUsage is the total number of bytes the queue and its tasks require
+	// to be stored in redis. It is an approximate memory usage value in bytes
+	// since the value is computed by sampling.
+	MemoryUsage int64
+	// Paused indicates whether the queue is paused.
+	// If true, tasks in the queue should not be processed.
+	Paused bool
+	// Size is the total number of tasks in the queue.
+	Size int
+
+	// Groups is the total number of groups in the queue.
+	Groups int
+
+	// Number of tasks in each state.
+	Pending     int
+	Active      int
+	Scheduled   int
+	Retry       int
+	Archived    int
+	Completed   int
+	Aggregating int
+
+	// Number of tasks processed within the current date.
+	// The number includes both succeeded and failed tasks.
+	Processed int
+	// Number of tasks failed within the current date.
+	Failed int
+
+	// Total number of tasks processed (both succeeded and failed) from this queue.
+	ProcessedTotal int
+	// Total number of tasks failed.
+	FailedTotal int
+
+	// Latency of the queue, measured by the oldest pending task in the queue.
+	Latency time.Duration
+	// Time this stats was taken.
+	Timestamp time.Time
+}
+
+// DailyStats holds aggregate data for a given day.
+type DailyStats struct {
+	// Name of the queue (e.g. "default", "critical").
+	Queue string
+	// Total number of tasks processed during the given day.
+	// The number includes both succeeded and failed tasks.
+	Processed int
+	// Total number of tasks failed during the given day.
+	Failed int
+	// Date this stats was taken.
+	Time time.Time
+}

--- a/internal/rdb/inspect_test.go
+++ b/internal/rdb/inspect_test.go
@@ -85,7 +85,7 @@ func TestCurrentStats(t *testing.T) {
 		paused                          []string
 		oldestPendingMessageEnqueueTime map[string]time.Time
 		qname                           string
-		want                            *Stats
+		want                            *base.Stats
 	}{
 		{
 			tasks: []*h.TaskSeedData{
@@ -166,7 +166,7 @@ func TestCurrentStats(t *testing.T) {
 			},
 			paused: []string{},
 			qname:  "default",
-			want: &Stats{
+			want: &base.Stats{
 				Queue:          "default",
 				Paused:         false,
 				Size:           5,
@@ -255,7 +255,7 @@ func TestCurrentStats(t *testing.T) {
 			},
 			paused: []string{"critical", "low"},
 			qname:  "critical",
-			want: &Stats{
+			want: &base.Stats{
 				Queue:          "critical",
 				Paused:         true,
 				Size:           0,
@@ -321,7 +321,7 @@ func TestCurrentStats(t *testing.T) {
 			continue
 		}
 
-		ignoreMemUsg := cmpopts.IgnoreFields(Stats{}, "MemoryUsage")
+		ignoreMemUsg := cmpopts.IgnoreFields(base.Stats{}, "MemoryUsage")
 		if diff := cmp.Diff(tc.want, got, timeCmpOpt, ignoreMemUsg); diff != "" {
 			t.Errorf("r.CurrentStats(%q) = %v, %v, want %v, nil; (-want, +got)\n%s", tc.qname, got, err, tc.want, diff)
 			continue
@@ -379,7 +379,7 @@ func TestHistoricalStats(t *testing.T) {
 		}
 
 		for i := 0; i < tc.n; i++ {
-			want := &DailyStats{
+			want := &base.DailyStats{
 				Queue:     tc.qname,
 				Processed: (i + 1) * 1000,
 				Failed:    (i + 1) * 10,
@@ -468,12 +468,12 @@ func TestGroupStats(t *testing.T) {
 	tests := []struct {
 		desc  string
 		qname string
-		want  []*GroupStat
+		want  []*base.GroupStat
 	}{
 		{
 			desc:  "default queue groups",
 			qname: "default",
-			want: []*GroupStat{
+			want: []*base.GroupStat{
 				{Group: "group1", Size: 3},
 				{Group: "group2", Size: 1},
 			},
@@ -481,7 +481,7 @@ func TestGroupStats(t *testing.T) {
 		{
 			desc:  "custom queue groups",
 			qname: "custom",
-			want: []*GroupStat{
+			want: []*base.GroupStat{
 				{Group: "group1", Size: 2},
 			},
 		},
@@ -489,8 +489,8 @@ func TestGroupStats(t *testing.T) {
 
 	var sortGroupStatsOpt = cmp.Transformer(
 		"SortGroupStats",
-		func(in []*GroupStat) []*GroupStat {
-			out := append([]*GroupStat(nil), in...)
+		func(in []*base.GroupStat) []*base.GroupStat {
+			out := append([]*base.GroupStat(nil), in...)
 			sort.Slice(out, func(i, j int) bool {
 				return out[i].Group < out[j].Group
 			})
@@ -809,7 +809,7 @@ func TestListPending(t *testing.T) {
 	}
 }
 
-func TestListPendingbase.Pagination(t *testing.T) {
+func TestListPendingPagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	var msgs []*base.TaskMessage
@@ -928,7 +928,7 @@ func TestListActive(t *testing.T) {
 	}
 }
 
-func TestListActivebase.Pagination(t *testing.T) {
+func TestListActivePagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	var msgs []*base.TaskMessage
@@ -1063,7 +1063,7 @@ func TestListScheduled(t *testing.T) {
 	}
 }
 
-func TestListScheduledbase.Pagination(t *testing.T) {
+func TestListScheduledPagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	// create 100 tasks with an increasing number of wait time.
@@ -1218,7 +1218,7 @@ func TestListRetry(t *testing.T) {
 	}
 }
 
-func TestListRetrybase.Pagination(t *testing.T) {
+func TestListRetryPagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	// create 100 tasks with an increasing number of wait time.
@@ -1371,7 +1371,7 @@ func TestListArchived(t *testing.T) {
 	}
 }
 
-func TestListArchivedbase.Pagination(t *testing.T) {
+func TestListArchivedPagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	var entries []base.Z
@@ -1512,7 +1512,7 @@ func TestListCompleted(t *testing.T) {
 
 }
 
-func TestListCompletedbase.Pagination(t *testing.T) {
+func TestListCompletedPagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	var entries []base.Z
@@ -1656,7 +1656,7 @@ func TestListAggregating(t *testing.T) {
 	}
 }
 
-func TestListAggregatingbase.Pagination(t *testing.T) {
+func TestListAggregatingPagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 

--- a/internal/rdb/inspect_test.go
+++ b/internal/rdb/inspect_test.go
@@ -796,8 +796,8 @@ func TestListPending(t *testing.T) {
 		h.FlushDB(t, r.client) // clean up db before each test case
 		h.SeedAllPendingQueues(t, r.client, tc.pending)
 
-		got, err := r.ListPending(tc.qname, Pagination{Size: 20, Page: 0})
-		op := fmt.Sprintf("r.ListPending(%q, Pagination{Size: 20, Page: 0})", tc.qname)
+		got, err := r.ListPending(tc.qname, base.Pagination{Size: 20, Page: 0})
+		op := fmt.Sprintf("r.ListPending(%q, base.Pagination{Size: 20, Page: 0})", tc.qname)
 		if err != nil {
 			t.Errorf("%s = %v, %v, want %v, nil", op, got, err, tc.want)
 			continue
@@ -809,7 +809,7 @@ func TestListPending(t *testing.T) {
 	}
 }
 
-func TestListPendingPagination(t *testing.T) {
+func TestListPendingbase.Pagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	var msgs []*base.TaskMessage
@@ -846,8 +846,8 @@ func TestListPendingPagination(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got, err := r.ListPending(tc.qname, Pagination{Size: tc.size, Page: tc.page})
-		op := fmt.Sprintf("r.ListPending(%q, Pagination{Size: %d, Page: %d})", tc.qname, tc.size, tc.page)
+		got, err := r.ListPending(tc.qname, base.Pagination{Size: tc.size, Page: tc.page})
+		op := fmt.Sprintf("r.ListPending(%q, base.Pagination{Size: %d, Page: %d})", tc.qname, tc.size, tc.page)
 		if err != nil {
 			t.Errorf("%s; %s returned error %v", tc.desc, op, err)
 			continue
@@ -915,8 +915,8 @@ func TestListActive(t *testing.T) {
 		h.FlushDB(t, r.client) // clean up db before each test case
 		h.SeedAllActiveQueues(t, r.client, tc.inProgress)
 
-		got, err := r.ListActive(tc.qname, Pagination{Size: 20, Page: 0})
-		op := fmt.Sprintf("r.ListActive(%q, Pagination{Size: 20, Page: 0})", tc.qname)
+		got, err := r.ListActive(tc.qname, base.Pagination{Size: 20, Page: 0})
+		op := fmt.Sprintf("r.ListActive(%q, base.Pagination{Size: 20, Page: 0})", tc.qname)
 		if err != nil {
 			t.Errorf("%s = %v, %v, want %v, nil", op, got, err, tc.inProgress)
 			continue
@@ -928,7 +928,7 @@ func TestListActive(t *testing.T) {
 	}
 }
 
-func TestListActivePagination(t *testing.T) {
+func TestListActivebase.Pagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	var msgs []*base.TaskMessage
@@ -955,8 +955,8 @@ func TestListActivePagination(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got, err := r.ListActive(tc.qname, Pagination{Size: tc.size, Page: tc.page})
-		op := fmt.Sprintf("r.ListActive(%q, Pagination{Size: %d, Page: %d})", tc.qname, tc.size, tc.page)
+		got, err := r.ListActive(tc.qname, base.Pagination{Size: tc.size, Page: tc.page})
+		op := fmt.Sprintf("r.ListActive(%q, base.Pagination{Size: %d, Page: %d})", tc.qname, tc.size, tc.page)
 		if err != nil {
 			t.Errorf("%s; %s returned error %v", tc.desc, op, err)
 			continue
@@ -1050,8 +1050,8 @@ func TestListScheduled(t *testing.T) {
 		h.FlushDB(t, r.client) // clean up db before each test case
 		h.SeedAllScheduledQueues(t, r.client, tc.scheduled)
 
-		got, err := r.ListScheduled(tc.qname, Pagination{Size: 20, Page: 0})
-		op := fmt.Sprintf("r.ListScheduled(%q, Pagination{Size: 20, Page: 0})", tc.qname)
+		got, err := r.ListScheduled(tc.qname, base.Pagination{Size: 20, Page: 0})
+		op := fmt.Sprintf("r.ListScheduled(%q, base.Pagination{Size: 20, Page: 0})", tc.qname)
 		if err != nil {
 			t.Errorf("%s = %v, %v, want %v, nil", op, got, err, tc.want)
 			continue
@@ -1063,7 +1063,7 @@ func TestListScheduled(t *testing.T) {
 	}
 }
 
-func TestListScheduledPagination(t *testing.T) {
+func TestListScheduledbase.Pagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	// create 100 tasks with an increasing number of wait time.
@@ -1091,8 +1091,8 @@ func TestListScheduledPagination(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got, err := r.ListScheduled(tc.qname, Pagination{Size: tc.size, Page: tc.page})
-		op := fmt.Sprintf("r.ListScheduled(%q, Pagination{Size: %d, Page: %d})", tc.qname, tc.size, tc.page)
+		got, err := r.ListScheduled(tc.qname, base.Pagination{Size: tc.size, Page: tc.page})
+		op := fmt.Sprintf("r.ListScheduled(%q, base.Pagination{Size: %d, Page: %d})", tc.qname, tc.size, tc.page)
 		if err != nil {
 			t.Errorf("%s; %s returned error %v", tc.desc, op, err)
 			continue
@@ -1204,8 +1204,8 @@ func TestListRetry(t *testing.T) {
 		h.FlushDB(t, r.client) // clean up db before each test case
 		h.SeedAllRetryQueues(t, r.client, tc.retry)
 
-		got, err := r.ListRetry(tc.qname, Pagination{Size: 20, Page: 0})
-		op := fmt.Sprintf("r.ListRetry(%q, Pagination{Size: 20, Page: 0})", tc.qname)
+		got, err := r.ListRetry(tc.qname, base.Pagination{Size: 20, Page: 0})
+		op := fmt.Sprintf("r.ListRetry(%q, base.Pagination{Size: 20, Page: 0})", tc.qname)
 		if err != nil {
 			t.Errorf("%s = %v, %v, want %v, nil", op, got, err, tc.want)
 			continue
@@ -1218,7 +1218,7 @@ func TestListRetry(t *testing.T) {
 	}
 }
 
-func TestListRetryPagination(t *testing.T) {
+func TestListRetrybase.Pagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	// create 100 tasks with an increasing number of wait time.
@@ -1248,8 +1248,8 @@ func TestListRetryPagination(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got, err := r.ListRetry(tc.qname, Pagination{Size: tc.size, Page: tc.page})
-		op := fmt.Sprintf("r.ListRetry(%q, Pagination{Size: %d, Page: %d})",
+		got, err := r.ListRetry(tc.qname, base.Pagination{Size: tc.size, Page: tc.page})
+		op := fmt.Sprintf("r.ListRetry(%q, base.Pagination{Size: %d, Page: %d})",
 			tc.qname, tc.size, tc.page)
 		if err != nil {
 			t.Errorf("%s; %s returned error %v", tc.desc, op, err)
@@ -1357,8 +1357,8 @@ func TestListArchived(t *testing.T) {
 		h.FlushDB(t, r.client) // clean up db before each test case
 		h.SeedAllArchivedQueues(t, r.client, tc.archived)
 
-		got, err := r.ListArchived(tc.qname, Pagination{Size: 20, Page: 0})
-		op := fmt.Sprintf("r.ListArchived(%q, Pagination{Size: 20, Page: 0})", tc.qname)
+		got, err := r.ListArchived(tc.qname, base.Pagination{Size: 20, Page: 0})
+		op := fmt.Sprintf("r.ListArchived(%q, base.Pagination{Size: 20, Page: 0})", tc.qname)
 		if err != nil {
 			t.Errorf("%s = %v, %v, want %v, nil", op, got, err, tc.want)
 			continue
@@ -1371,7 +1371,7 @@ func TestListArchived(t *testing.T) {
 	}
 }
 
-func TestListArchivedPagination(t *testing.T) {
+func TestListArchivedbase.Pagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	var entries []base.Z
@@ -1398,8 +1398,8 @@ func TestListArchivedPagination(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got, err := r.ListArchived(tc.qname, Pagination{Size: tc.size, Page: tc.page})
-		op := fmt.Sprintf("r.ListArchived(Pagination{Size: %d, Page: %d})",
+		got, err := r.ListArchived(tc.qname, base.Pagination{Size: tc.size, Page: tc.page})
+		op := fmt.Sprintf("r.ListArchived(base.Pagination{Size: %d, Page: %d})",
 			tc.size, tc.page)
 		if err != nil {
 			t.Errorf("%s; %s returned error %v", tc.desc, op, err)
@@ -1497,8 +1497,8 @@ func TestListCompleted(t *testing.T) {
 		h.FlushDB(t, r.client) // clean up db before each test case
 		h.SeedAllCompletedQueues(t, r.client, tc.completed)
 
-		got, err := r.ListCompleted(tc.qname, Pagination{Size: 20, Page: 0})
-		op := fmt.Sprintf("r.ListCompleted(%q, Pagination{Size: 20, Page: 0})", tc.qname)
+		got, err := r.ListCompleted(tc.qname, base.Pagination{Size: 20, Page: 0})
+		op := fmt.Sprintf("r.ListCompleted(%q, base.Pagination{Size: 20, Page: 0})", tc.qname)
 		if err != nil {
 			t.Errorf("%s = %v, %v, want %v, nil", op, got, err, tc.want)
 			continue
@@ -1512,7 +1512,7 @@ func TestListCompleted(t *testing.T) {
 
 }
 
-func TestListCompletedPagination(t *testing.T) {
+func TestListCompletedbase.Pagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 	var entries []base.Z
@@ -1539,8 +1539,8 @@ func TestListCompletedPagination(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got, err := r.ListCompleted(tc.qname, Pagination{Size: tc.size, Page: tc.page})
-		op := fmt.Sprintf("r.ListCompleted(Pagination{Size: %d, Page: %d})",
+		got, err := r.ListCompleted(tc.qname, base.Pagination{Size: tc.size, Page: tc.page})
+		op := fmt.Sprintf("r.ListCompleted(base.Pagination{Size: %d, Page: %d})",
 			tc.size, tc.page)
 		if err != nil {
 			t.Errorf("%s; %s returned error %v", tc.desc, op, err)
@@ -1645,7 +1645,7 @@ func TestListAggregating(t *testing.T) {
 		h.SeedRedisZSets(t, r.client, fxt.groups)
 
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := r.ListAggregating(tc.qname, tc.gname, Pagination{})
+			got, err := r.ListAggregating(tc.qname, tc.gname, base.Pagination{})
 			if err != nil {
 				t.Fatalf("ListAggregating returned error: %v", err)
 			}
@@ -1656,7 +1656,7 @@ func TestListAggregating(t *testing.T) {
 	}
 }
 
-func TestListAggregatingPagination(t *testing.T) {
+func TestListAggregatingbase.Pagination(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 
@@ -1759,7 +1759,7 @@ func TestListAggregatingPagination(t *testing.T) {
 		h.SeedRedisZSets(t, r.client, fxt.groups)
 
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := r.ListAggregating(tc.qname, tc.gname, Pagination{Page: tc.page, Size: tc.size})
+			got, err := r.ListAggregating(tc.qname, tc.gname, base.Pagination{Page: tc.page, Size: tc.size})
 			if err != nil {
 				t.Fatalf("ListAggregating returned error: %v", err)
 			}
@@ -1802,7 +1802,7 @@ func TestListTasksError(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		pgn := Pagination{Page: 0, Size: 20}
+		pgn := base.Pagination{Page: 0, Size: 20}
 		if _, got := r.ListActive(tc.qname, pgn); !tc.match(got) {
 			t.Errorf("%s: ListActive returned %v", tc.desc, got)
 		}
@@ -5418,7 +5418,7 @@ loop:
 				continue loop
 			}
 		}
-		got, err := r.ListSchedulerEnqueueEvents(tc.entryID, Pagination{Size: 20, Page: 0})
+		got, err := r.ListSchedulerEnqueueEvents(tc.entryID, base.Pagination{Size: 20, Page: 0})
 		if err != nil {
 			t.Errorf("ListSchedulerEnqueueEvents(%q) failed: %v", tc.entryID, err)
 			continue
@@ -5465,7 +5465,7 @@ func TestRecordSchedulerEnqueueEventTrimsDataSet(t *testing.T) {
 	if n := r.client.ZCard(context.Background(), key).Val(); n != maxEvents {
 		t.Fatalf("unexpected number of events; got %d, want %d", n, maxEvents)
 	}
-	events, err := r.ListSchedulerEnqueueEvents(entryID, Pagination{Size: maxEvents})
+	events, err := r.ListSchedulerEnqueueEvents(entryID, base.Pagination{Size: maxEvents})
 	if err != nil {
 		t.Fatalf("ListSchedulerEnqueueEvents failed: %v", err)
 	}


### PR DESCRIPTION
This is a code structure change, not a functional one. There is a `base.Broker` interface that RDB implements, so I wanted to do the same for the Inspector. 

This PR adds the interface `base.QueueInspector` and moves some types to the `base` package in order to avoid circular dependencies. As expected, RDB already implements both `base.QueueInspector` and `base.Broker`.

**Why?**. To make the CLI and UI work with different broker implementations. I would like to add another broker to this library, backed by MongoDB. `base.Broker` works fine, I have implemented basic features, but it needs this new interface to add support in the CLI and UI.

All tests are passing. 