### PR TITLE
update the lua scripts when executing the enqueueCmd

### DIFF
--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -94,14 +94,14 @@ func (r *RDB) runScriptWithErrorCode(ctx context.Context, op errors.Op, script *
 // Returns 1 if successfully enqueued
 // Returns 0 if task ID already exists
 var enqueueCmd = redis.NewScript(`
-if redis.call("EXISTS", KEYS[1]) == 1 then
+if redis.call("EXISTS", KEYS[0]) == 1 then
 	return 0
 end
-redis.call("HSET", KEYS[1],
+redis.call("HSET", KEYS[0],
            "msg", ARGV[1],
            "state", "pending",
            "pending_since", ARGV[3])
-redis.call("LPUSH", KEYS[2], ARGV[2])
+redis.call("LPUSH", KEYS[0], ARGV[2])
 return 1
 `)
 


### PR DESCRIPTION
when i use redis version is 3.0.504,system can panic the wrong number of args,and i fix this error when i update this coding.i cant know this question  caused by the redis interface version.