### PR TITLE
 Some Redis hset command parameter issues on different platform versions need to be fixed

### DIFF
--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -97,10 +97,9 @@ var enqueueCmd = redis.NewScript(`
 if redis.call("EXISTS", KEYS[1]) == 1 then
 	return 0
 end
-redis.call("HSET", KEYS[1],
-           "msg", ARGV[1],
-           "state", "pending",
-           "pending_since", ARGV[3])
+redis.call("HSET", KEYS[1], "msg", ARGV[1])
+redis.call("HSET", KEYS[1], "state", "pending")
+redis.call("HSET", KEYS[1], "pending_since", ARGV[3])
 redis.call("LPUSH", KEYS[2], ARGV[2])
 return 1
 `)


### PR DESCRIPTION
The Redis hset command does not support more than three parameters in certain versions
for example: asynq/internal/rdb/rdb.go [lineNumber: 96]
```go
var enqueueCmd = redis.NewScript(`
if redis.call("EXISTS", KEYS[1]) == 1 then
	return 0
end
redis.call("HSET", KEYS[1],
           "msg", ARGV[1],
           "state", "pending",
           "pending_since", ARGV[3])
redis.call("LPUSH", KEYS[2], ARGV[2])
return 1
`)
```
---
To support some platform versions of Redis, it needs to be changed to the following content
```go
var enqueueCmd = redis.NewScript(`
if redis.call("EXISTS", KEYS[1]) == 1 then
	return 0
end
redis.call("HSET", KEYS[1], "msg", ARGV[1])
redis.call("HSET", KEYS[1], "state", "pending")
redis.call("HSET", KEYS[1], "pending_since", ARGV[3])
redis.call("LPUSH", KEYS[2], ARGV[2])
return 1
`)
```