### PR TITLE
fix: queues map init with size

### DIFF
--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -375,7 +375,7 @@ func EncodeServerInfo(info *ServerInfo) ([]byte, error) {
 	if info == nil {
 		return nil, fmt.Errorf("cannot encode nil server info")
 	}
-	queues := make(map[string]int32)
+	queues := make(map[string]int32, len(info.Queues))
 	for q, p := range info.Queues {
 		queues[q] = int32(p)
 	}
@@ -402,7 +402,7 @@ func DecodeServerInfo(b []byte) (*ServerInfo, error) {
 	if err := proto.Unmarshal(b, &pbmsg); err != nil {
 		return nil, err
 	}
-	queues := make(map[string]int)
+	queues := make(map[string]int, len(pbmsg.GetQueues()))
 	for q, p := range pbmsg.GetQueues() {
 		queues[q] = int(p)
 	}


### PR DESCRIPTION
Initializing the queue can improve performance and reduce the number of map expansions. When there are 10 queues, the following is my performance test:

```shell
goos: linux
goarch: amd64
pkg: go-all-in-one/map
cpu: AMD EPYC 7K62 48-Core Processor
BenchmarkWithSize-8 2684252 447.0 ns/op 576 B/op 1 allocs/op
BenchmarkWithoutSize-8 2147931 557.8 ns/op 292 B/op 1 allocs/op
```