### PR TITLE
(workflow): bump go version to 1.18 in benchstat

### DIFF
--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.18.x
       - name: Install benchstat
         run: go get -u golang.org/x/perf/cmd/benchstat
       - name: Download Incoming


### PR DESCRIPTION
Fix for #744 