### PR TITLE
Adding a method to return a task's opts

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -35,6 +35,7 @@ type Task struct {
 
 func (t *Task) Type() string    { return t.typename }
 func (t *Task) Payload() []byte { return t.payload }
+func (t *Task) Options() []Option { return t.opts }
 
 // ResultWriter returns a pointer to the ResultWriter associated with the task.
 //


### PR DESCRIPTION
I'd like to add an `Options()` method to `Task` that returns the `[]Option` stored in `t.opts`.

My use case is that I'd like to be able to modify a task's payload inside a middleware.  I haven't found a way that I can do that without losing the tasks options. 

The way I'm currently doing it is as follows.

~~~
newTask  := asynq.NewTask(t.Type(), newPayload)
return h.ProcessTask(ctx, newTask)
~~~

I believe adding an `Options()` method to task is needed to preserve the options.

~~~
newTask := asynq.NewTask(t.Type(), newPayload, t.Options()...)
return h.ProcessTask(ctx, newTask)
~~~

If there is a better or already existing way to accomplish my use case I'd be happy to use that. Please let me know if adding the method and my use case is sane. 

Thanks!