### PR TITLE
include version in CLI README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Asynq ships with a command line tool to inspect the state of queues and tasks.
 To install the CLI tool, run the following command:
 
 ```sh
-go install github.com/hibiken/asynq/tools/asynq
+go install github.com/hibiken/asynq/tools/asynq@latest
 ```
 
 Here's an example of running the `asynq dash` command:

--- a/tools/asynq/README.md
+++ b/tools/asynq/README.md
@@ -12,7 +12,7 @@ Asynq CLI is a command line tool to monitor the queues and tasks managed by `asy
 
 In order to use the tool, compile it using the following command:
 
-    go install github.com/hibiken/asynq/tools/asynq
+    go install github.com/hibiken/asynq/tools/asynq@latest
 
 This will create the asynq executable under your `$GOPATH/bin` directory.
 


### PR DESCRIPTION
Current installation instructions produce an error:
```
$ go install github.com/hibiken/asynq/tools/asynq
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/hibiken/asynq/tools/asynq@latest' to install the latest version
```

PR updates README files to include `latest` version