### PR TITLE
Fix go:build for BSD

### DIFF
--- a/signals_unix.go
+++ b/signals_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || bsd || darwin
+//go:build linux || dragonfly || freebsd || netbsd || openbsd || darwin
 
 package asynq
 


### PR DESCRIPTION
I've been running into the following build issue on a project that uses asynq:

```log
  ⨯ release failed after 5m12s               error=failed to build for openbsd_386: exit status 1: # github.com/hibiken/asynq
Error: ../../../go/pkg/mod/github.com/hibiken/asynq@v0.24.1/periodic_task_manager.go:152:8: mgr.s.waitForSignals undefined (type *Scheduler has no field or method waitForSignals)
Error: ../../../go/pkg/mod/github.com/hibiken/asynq@v0.24.1/scheduler.go:212:4: s.waitForSignals undefined (type *Scheduler has no field or method waitForSignals)
Error: ../../../go/pkg/mod/github.com/hibiken/asynq@v0.24.1/server.go:594:6: srv.waitForSignals undefined (type *Server has no field or method waitForSignals)
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.24.0/x64/goreleaser' failed with exit code 1
```

Upon fruther investigation it appears that the `go:build` flag `bsd` is not correct. The `go tool dist list` command doesn't list any platform named `bsd`. Hence I believe `bsd` needs to be replaced with the actual BSD platforms. I don't know whether you would want to include `solaris` as well, and whether there's anyone using it/able to test it on that platform, hence I left it out.