### PR TITLE
Add jitter on the processor fetch backoff sleep

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -181,7 +181,8 @@ func (p *processor) exec() {
 			// Sleep to avoid slamming redis and let scheduler move tasks into queues.
 			// Note: We are not using blocking pop operation and polling queues instead.
 			// This adds significant load to redis.
-			time.Sleep(p.taskCheckInterval)
+			jitter := time.Duration(rand.Intn(int(p.taskCheckInterval)))
+			time.Sleep(p.taskCheckInterval/2 + jitter)
 			<-p.sema // release token
 			return
 		case err != nil:


### PR DESCRIPTION
## Changes

This PR adds some jitter to the backoff sleep of the processor fetch loop to avoid workers synchronization, and thus improve worker efficiency and job latency.

## Context

We run dozens of workers, with an execution rate of up to 5K jobs/sec.

We started to suspect that the job workers were significantly inefficient.

1. Changing the TaskCheckInterval from 1s (default) to 100ms has reduced the latency from ~500ms to 40ms on a high traffic worker pool, and 10ms to a low traffic worker pool.

2. Then, adding the jitter has further reduced the latency to 2 ms on both high and low traffic worker pool.

Synchronization on a distributed system is well known, and adding jitter helped avoid it.



Impact of adding a jitter: Queue size:
<img width="567" alt="Screenshot 2024-04-15 at 19 05 32" src="https://github.com/hibiken/asynq/assets/60219/5b2fc86e-5e13-42cf-9e2a-0e9dd8efe05c">

Latency:
<img width="570" alt="Screenshot 2024-04-15 at 19 05 51" src="https://github.com/hibiken/asynq/assets/60219/a8e634f6-6224-455d-8a08-6743a2d81b20">
