### PR TITLE
perf: Reuse rand for shuffling queues

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -70,6 +70,9 @@ type processor struct {
 
 	starting chan<- *workerInfo
 	finished chan<- *base.TaskMessage
+
+	// queueShuffleRand holds the random source to shuffle the queues.
+	queueShuffleRand *rand.Rand
 }
 
 type processorParams struct {
@@ -119,6 +122,7 @@ func newProcessor(params processorParams) *processor {
 		shutdownTimeout:   params.shutdownTimeout,
 		starting:          params.starting,
 		finished:          params.finished,
+		queueShuffleRand:  rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -404,8 +408,8 @@ func (p *processor) queues() []string {
 			names = append(names, qname)
 		}
 	}
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	r.Shuffle(len(names), func(i, j int) { names[i], names[j] = names[j], names[i] })
+	p.queueShuffleRand.Seed(time.Now().UnixNano())
+	p.queueShuffleRand.Shuffle(len(names), func(i, j int) { names[i], names[j] = names[j], names[i] })
 	return uniq(names, len(p.queueConfig))
 }
 


### PR DESCRIPTION
Instead of creating a new `rand.Rand` every time we need the next queues, we create it once and reuse it.

The reason for this change comes from monitoring our application: After a few minutes, the `github.com/hibiken/asynq.(*processor).queues` method will consume a tremendous amount of CPU time and create a lot of garbage.

Since the `queue` method is called in its own goroutine, there is no need to add any synchronization primitives.

Here is the profiling flame graph of our application in a time window of 5 minutes:
![image](https://github.com/user-attachments/assets/d6b08fdf-f921-446f-a059-0b8caae444c7)
