### PR TITLE
Configure dependabot to update Github Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,4 +18,7 @@ updates:
       interval: "weekly"
     labels:
       - "pr-deps"
-      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Some Github Actions are very old, and needs to be updated. Example: https://github.com/hibiken/asynq/actions/runs/11521778134

<img width="1927" alt="Screenshot 2024-10-25 at 18 32 49" src="https://github.com/user-attachments/assets/e2676e20-462a-4351-9f9d-d04c35a7ab2f">
