### PR TITLE
Use math/rand/v2

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"runtime/debug"
 	"sort"
@@ -181,7 +181,7 @@ func (p *processor) exec() {
 			// Sleep to avoid slamming redis and let scheduler move tasks into queues.
 			// Note: We are not using blocking pop operation and polling queues instead.
 			// This adds significant load to redis.
-			jitter := time.Duration(rand.Intn(int(p.taskCheckInterval)))
+			jitter := rand.N(p.taskCheckInterval)
 			time.Sleep(p.taskCheckInterval/2 + jitter)
 			<-p.sema // release token
 			return
@@ -413,8 +413,7 @@ func (p *processor) queues() []string {
 			names = append(names, qname)
 		}
 	}
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	r.Shuffle(len(names), func(i, j int) { names[i], names[j] = names[j], names[i] })
+	rand.Shuffle(len(names), func(i, j int) { names[i], names[j] = names[j], names[i] })
 	return uniq(names, len(p.queueConfig))
 }
 

--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strings"
 	"sync"
@@ -400,9 +400,8 @@ func toInternalLogLevel(l LogLevel) log.Level {
 // DefaultRetryDelayFunc is the default RetryDelayFunc used if one is not specified in Config.
 // It uses exponential back-off strategy to calculate the retry delay.
 func DefaultRetryDelayFunc(n int, e error, t *Task) time.Duration {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	// Formula taken from https://github.com/mperham/sidekiq.
-	s := int(math.Pow(float64(n), 4)) + 15 + (r.Intn(30) * (n + 1))
+	s := int(math.Pow(float64(n), 4)) + 15 + (rand.IntN(30) * (n + 1))
 	return time.Duration(s) * time.Second
 }
 


### PR DESCRIPTION
## Context 

We want to start using `math/rand/v2` since it fixed many flaws of `math/rand`, and is more performance.
https://go.dev/blog/randv2

Replaces https://github.com/hibiken/asynq/pull/916 

Refs:
- https://github.com/hibiken/asynq/pull/916#issuecomment-2437054813
- https://github.com/hibiken/asynq/pull/868#issuecomment-2423659098

## Changes

- Update the Processor and Server components to use `math/rand/v2`