### PR TITLE
Add NewClientWithExistingRedisClient to create a client with an existing Redis connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,6 +41,16 @@ func NewClient(r RedisConnOpt) *Client {
 	return client
 }
 
+// NewClientWithExistingRedisClient returns a new Client instance given a redis.UniversalClient already created
+func NewClientWithExistingRedisClient(redisClient redis.UniversalClient) *Client {
+	if err := redisClient.Ping(context.Background()).Err(); err != nil {
+		panic(fmt.Sprintf("asynq: failed to ping Redis: %v", err))
+	}
+	client := NewClientFromRedisClient(redisClient)
+	client.sharedConnection = false
+	return client
+}
+
 // NewClientFromRedisClient returns a new instance of Client given a redis.UniversalClient
 // Warning: The underlying redis connection pool will not be closed by Asynq, you are responsible for closing it.
 func NewClientFromRedisClient(c redis.UniversalClient) *Client {


### PR DESCRIPTION
**PR Description**

This PR introduces a new function NewClientWithExistingRedisClient to the Client struct. This function allows the creation of a Client instance using an already established redis.UniversalClient.  

**Changes:**

- Added NewClientWithExistingRedisClient function.

- New Function Pings the provided Redis client to ensure connectivity.

- Creates a new Client instance using the existing Redis client.

- Sets the sharedConnection flag to false to indicate that the connection should not be closed by the Client.


This enhancement is useful for scenarios where the Redis connection is managed externally and should not be closed by the Client.

I personally had a project usecase where I didn't want to pass the username password as I wanted to reuse the existing redis client and thus made this addtion.