### PR TITLE
fix: mark the client that the scheduler made also as non-shared

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -60,6 +60,7 @@ func NewScheduler(r RedisConnOpt, opts *SchedulerOpts) *Scheduler {
 	}
 	scheduler := NewSchedulerFromRedisClient(redisClient, opts)
 	scheduler.sharedConnection = false
+	scheduler.client.sharedConnection = false
 	return scheduler
 }
 


### PR DESCRIPTION
the `redisClient` that the `NewScheduler` makes should also be marked as non-shared, otherwise it throws the error 
```
ERROR Failed to close redis client connection: redis connection is shared so the Client can't be closed through asynq
```
on shutdown.