### PR TITLE
feat: allow custom broker

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,13 @@ func NewClient(r RedisConnOpt) *Client {
 // NewClientFromRedisClient returns a new instance of Client given a redis.UniversalClient
 // Warning: The underlying redis connection pool will not be closed by Asynq, you are responsible for closing it.
 func NewClientFromRedisClient(c redis.UniversalClient) *Client {
-	return &Client{broker: rdb.NewRDB(c), sharedConnection: true}
+	return NewClientFromBroker(rdb.NewRDB(c))
+}
+
+// NewClientFromBroker returns a new instance of Client given a broker.
+// Warning: The underlying broker will not be closed by Asynq, you are responsible for closing it.
+func NewClientFromBroker(b base.Broker) *Client {
+	return &Client{broker: b, sharedConnection: true}
 }
 
 type OptionType int

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hibiken/asynq/internal/errors"
 	pb "github.com/hibiken/asynq/internal/proto"
 	"github.com/hibiken/asynq/internal/timeutil"
-	"github.com/redis/go-redis/v9"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -718,8 +717,14 @@ type Broker interface {
 	ClearServerState(host string, pid int, serverID string) error
 
 	// Cancelation related methods
-	CancelationPubSub() (*redis.PubSub, error) // TODO: Need to decouple from redis to support other brokers
+	SubscribeCancellation() (CancellationSubscription, error)
 	PublishCancelation(id string) error
 
 	WriteResult(qname, id string, data []byte) (n int, err error)
+}
+
+// CancellationSubscription is a subscription to cancellation messages.
+type CancellationSubscription interface {
+	Channel() <-chan string // returns a channel to receive the id of tasks to be cancelled.
+	Close() error           // closes the subscription.
 }

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -3236,12 +3236,12 @@ func TestCancelationPubSub(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 
-	pubsub, err := r.CancelationPubSub()
+	sub, err := r.SubscribeCancellation()
 	if err != nil {
 		t.Fatalf("(*RDB).CancelationPubSub() returned an error: %v", err)
 	}
 
-	cancelCh := pubsub.Channel()
+	cancelCh := sub.Channel()
 
 	var (
 		mu       sync.Mutex
@@ -3249,9 +3249,9 @@ func TestCancelationPubSub(t *testing.T) {
 	)
 
 	go func() {
-		for msg := range cancelCh {
+		for id := range cancelCh {
 			mu.Lock()
-			received = append(received, msg.Payload)
+			received = append(received, id)
 			mu.Unlock()
 		}
 	}()
@@ -3265,7 +3265,7 @@ func TestCancelationPubSub(t *testing.T) {
 	// allow for message to reach subscribers.
 	time.Sleep(time.Second)
 
-	pubsub.Close()
+	sub.Close()
 
 	mu.Lock()
 	if diff := cmp.Diff(publish, received, h.SortStringSliceOpt); diff != "" {

--- a/internal/testbroker/testbroker.go
+++ b/internal/testbroker/testbroker.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq/internal/base"
-	"github.com/redis/go-redis/v9"
 )
 
 var errRedisDown = errors.New("testutil: redis is down")
@@ -190,13 +189,13 @@ func (tb *TestBroker) ClearServerState(host string, pid int, serverID string) er
 	return tb.real.ClearServerState(host, pid, serverID)
 }
 
-func (tb *TestBroker) CancelationPubSub() (*redis.PubSub, error) {
+func (tb *TestBroker) SubscribeCancellation() (base.CancellationSubscription, error) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 	if tb.sleeping {
 		return nil, errRedisDown
 	}
-	return tb.real.CancelationPubSub()
+	return tb.real.SubscribeCancellation()
 }
 
 func (tb *TestBroker) PublishCancelation(id string) error {

--- a/subscriber.go
+++ b/subscriber.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/hibiken/asynq/internal/base"
 	"github.com/hibiken/asynq/internal/log"
 )
@@ -54,12 +53,12 @@ func (s *subscriber) start(wg *sync.WaitGroup) {
 	go func() {
 		defer wg.Done()
 		var (
-			pubsub *redis.PubSub
-			err    error
+			sub base.CancellationSubscription
+			err error
 		)
 		// Try until successfully connect to Redis.
 		for {
-			pubsub, err = s.broker.CancelationPubSub()
+			sub, err = s.broker.SubscribeCancellation()
 			if err != nil {
 				s.logger.Errorf("cannot subscribe to cancelation channel: %v", err)
 				select {
@@ -72,15 +71,15 @@ func (s *subscriber) start(wg *sync.WaitGroup) {
 			}
 			break
 		}
-		cancelCh := pubsub.Channel()
+		cancelCh := sub.Channel()
 		for {
 			select {
 			case <-s.done:
-				pubsub.Close()
+				sub.Close()
 				s.logger.Debug("Subscriber done")
 				return
-			case msg := <-cancelCh:
-				cancel, ok := s.cancelations.Get(msg.Payload)
+			case id := <-cancelCh:
+				cancel, ok := s.cancelations.Get(id)
 				if ok {
 					cancel()
 				}


### PR DESCRIPTION
This PR decouples `Broker` interface from redis and allows creating `Server` and `Client` directly from a broker instance. Which makes it possible for custom brokers.

For exmaple: Redis from our infrastructure doesn't support pubsub. But I can inherit RDB and implement the pub/sub in another way to make asynq work without a huge amount of work.
