### PR TITLE
fix: call Stop on all other signals to correctly set the server state

### DIFF
--- a/signals_unix.go
+++ b/signals_unix.go
@@ -24,8 +24,10 @@ func (srv *Server) waitForSignals() {
 		if sig == unix.SIGTSTP {
 			srv.Stop()
 			continue
+		} else {
+			srv.Stop()
+			break
 		}
-		break
 	}
 }
 


### PR DESCRIPTION
Ensures graceful shutdown of the server on UNIX systems.

* fixes: #979