### PR TITLE
Allow cancel without retry

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -336,15 +336,18 @@ func (p *processor) handleFailedMessage(ctx context.Context, l *base.Lease, msg 
 		p.errHandler.HandleError(ctx, NewTask(msg.Type, msg.Payload), err)
 	}
 	switch {
-	case errors.Is(err, RevokeTask):
-		p.logger.Warnf("revoke task id=%s", msg.ID)
-		p.markAsDone(l, msg)
-	case msg.Retried >= msg.Retry || errors.Is(err, SkipRetry):
-		p.logger.Warnf("Retry exhausted for task id=%s", msg.ID)
-		p.archive(l, msg, err)
-	default:
-		p.retry(l, msg, err, p.isFailureFunc(err))
-	}
+    case errors.Is(err, RevokeTask):
+        p.logger.Warnf("Revoke task id=%s", msg.ID)
+        p.markAsDone(l, msg)
+    case ctx.Err() == context.Canceled || errors.Is(err, SkipRetry):
+        p.logger.Warnf("Task canceled, skipping retry for id=%s", msg.ID)
+        p.archive(l, msg, err)
+    case msg.Retried >= msg.Retry:
+        p.logger.Warnf("Retry exhausted for task id=%s", msg.ID)
+        p.archive(l, msg, err)
+    default:
+        p.retry(l, msg, err, p.isFailureFunc(err))
+    }
 }
 
 func (p *processor) retry(l *base.Lease, msg *base.TaskMessage, e error, isFailure bool) {


### PR DESCRIPTION
Previously we couldn't cancel task without sending it to retry queue. Despite the fact that handler returned `SkipRetry` error, it didn't work correctly. Read from `<-ctx.Done()` in `processor.go:246` caused by canelation were and will be always earlier than returned `SkipRetry` from handler. That's why task always went to retry queue.

With these changes you are able to cancel task so it will be archived instead of going to retry :)