### PR TITLE
fix compatible with redis server verison 4.0

### DIFF
--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -866,7 +866,7 @@ if redis.call("ZREM", KEYS[3], ARGV[1]) == 0 then
   return redis.error_reply("NOT FOUND")
 end
 redis.call("ZADD", KEYS[4], ARGV[3], ARGV[1])
-local old = redis.call("ZRANGE", KEYS[4], "-inf", ARGV[4], "BYSCORE")
+local old = redis.call("ZRANGEBYSCORE", KEYS[4], "-inf", ARGV[4])
 if #old > 0 then
 	for _, id in ipairs(old) do
 		redis.call("DEL", KEYS[9] .. id)


### PR DESCRIPTION
as readme say `Version 4.0 or higher is required`, but  `zrange xxx byscore ` add from version 6.2.0
>> https://redis.io/docs/latest/commands/zrange/
>> Starting with Redis version 6.2.0: Added the REV, BYSCORE, BYLEX and LIMIT options.

---
in addition, 
https://github.com/hibiken/asynq/blob/489e21920b92ae6acfc19c54de91166e56817620/processor.go#L381
``` go
	err := p.broker.Archive(ctx, msg, e.Error())
	if err != nil {
```
The `err` do not print in log,  which can help debug