### PR TITLE
feat: Add QueueName method to ResultWriter for retrieving task queue …

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -549,3 +549,8 @@ func (w *ResultWriter) Write(data []byte) (n int, err error) {
 func (w *ResultWriter) TaskID() string {
 	return w.id
 }
+
+// QueueName returns the name of the queue the task belongs to.
+func (w *ResultWriter) QueueName() string {
+	return w.qname
+}


### PR DESCRIPTION
Would like to get the queue name from ResultWriter