### PR TITLE
servemux: `NotFoundHandler` returns `ErrHandlerNotFound` error

### DIFF
--- a/servemux.go
+++ b/servemux.go
@@ -6,11 +6,15 @@ package asynq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 )
+
+// ErrHandlerNotFound indicates that no task handler was found for a given pattern.
+var ErrHandlerNotFound = errors.New("handler not found for task")
 
 // ServeMux is a multiplexer for asynchronous tasks.
 // It matches the type of each task against a list of registered patterns
@@ -149,7 +153,7 @@ func (mux *ServeMux) Use(mws ...MiddlewareFunc) {
 
 // NotFound returns an error indicating that the handler was not found for the given task.
 func NotFound(ctx context.Context, task *Task) error {
-	return fmt.Errorf("handler not found for task %q", task.Type())
+	return fmt.Errorf("%w %q", ErrHandlerNotFound, task.Type())
 }
 
 // NotFoundHandler returns a simple task handler that returns a ``not found`` error.


### PR DESCRIPTION
The `asynq.NotFoundHandler` returns an error, which wraps `asynq.ErrHandlerNotFound` error.

This allows the use of middlewares, which can then inspect the returned error and decide to silence them, thus avoiding a retry.

Example middleware, which ignores `handler not found for task`.

```go
func NewIgnoreHandlerNotFoundMiddleware() asynq.MiddlewareFunc {
	middleware := func(handler asynq.Handler) asynq.Handler {
		mw := func(ctx context.Context, task *asynq.Task) error {
			err := handler.ProcessTask(ctx, task)
			if errors.Is(err, asynq.ErrHandlerNotFound) {
				slog.Info("ignoring task", "reason", asynq.ErrHandlerNotFound.Error())
				return nil
			}
			return err
		}
		return asynq.HandlerFunc(mw)
	}

	return asynq.MiddlewareFunc(middleware)
}
```

Use this middleware with a multiplexer.

``` go
...
mux := asynq.NewServeMux()
mux.Use(NewIgnoreHandlerNotFoundMiddleware())
...
server.Run(mux)
```