### PR TITLE
fix: remove redundent cache because it cause panels don't show the qu…

### DIFF
--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -114,12 +114,10 @@ func (r *RDB) Enqueue(ctx context.Context, msg *base.TaskMessage) error {
 	if err != nil {
 		return errors.E(op, errors.Unknown, fmt.Sprintf("cannot encode message: %v", err))
 	}
-	if _, found := r.queuesPublished.Load(msg.Queue); !found {
-		if err := r.client.SAdd(ctx, base.AllQueues, msg.Queue).Err(); err != nil {
-			return errors.E(op, errors.Unknown, &errors.RedisCommandError{Command: "sadd", Err: err})
-		}
-		r.queuesPublished.Store(msg.Queue, true)
+	if err := r.client.SAdd(ctx, base.AllQueues, msg.Queue).Err(); err != nil {
+		return errors.E(op, errors.Unknown, &errors.RedisCommandError{Command: "sadd", Err: err})
 	}
+	r.queuesPublished.Store(msg.Queue, true)
 	keys := []string{
 		base.TaskKey(msg.Queue, msg.ID),
 		base.PendingKey(msg.Queue),


### PR DESCRIPTION
in the code if the sync.Map remain, after deletion of each queue in panels like(asynqmon, aysnq-cli,...) the queue doesn't add to the redis set (asynq:queues).
this operation is idempotent. and the cost of it is low