### PR TITLE
Fix nil panic in memoryUsageCmd Lua script

### DIFF
--- a/internal/rdb/inspect.go
+++ b/internal/rdb/inspect.go
@@ -264,7 +264,9 @@ for i=1,2 do
     if (table.getn(ids) > 0) then
         for _, id in ipairs(ids) do
             local bytes = redis.call("MEMORY", "USAGE", ARGV[1] .. id)
-            sample_total = sample_total + bytes
+            if bytes then
+                sample_total = sample_total + bytes
+            end
         end
         local n = redis.call("LLEN", KEYS[i])
         local avg = sample_total / table.getn(ids)
@@ -281,7 +283,9 @@ for i=3,6 do
     if (table.getn(ids) > 0) then
         for _, id in ipairs(ids) do
             local bytes = redis.call("MEMORY", "USAGE", ARGV[1] .. id)
-            sample_total = sample_total + bytes
+            if bytes then
+                sample_total = sample_total + bytes
+            end
         end
         local n = redis.call("ZCARD", KEYS[i])
         local avg = sample_total / table.getn(ids)
@@ -304,13 +308,17 @@ if table.getn(groups) > 0 then
 			local ids = redis.call("ZRANGE", group_key, 0, sample_size - 1)
 			for _, id in ipairs(ids) do
 				local bytes = redis.call("MEMORY", "USAGE", ARGV[1] .. id)
-				agg_task_sample_total = agg_task_sample_total + bytes
-				agg_task_sample_size = agg_task_sample_size + 1
+				if bytes then
+					agg_task_sample_total = agg_task_sample_total + bytes
+					agg_task_sample_size = agg_task_sample_size + 1
+				end
 			end
 		end
 	end
-	local avg = agg_task_sample_total / agg_task_sample_size
-	memusg = memusg + (avg * agg_task_count)
+	if agg_task_sample_size > 0 then
+		local avg = agg_task_sample_total / agg_task_sample_size
+		memusg = memusg + (avg * agg_task_count)
+	end
 end
 return memusg
 `)


### PR DESCRIPTION
## Summary

`MEMORY USAGE` returns nil for Redis keys that no longer exist (e.g., expired or deleted task keys). In Lua, nil is converted to `false` (a boolean). The `memoryUsageCmd` script then attempts arithmetic on this boolean value, causing:

```
ERR user_script:30: attempt to perform arithmetic on local 'bytes' (a boolean value)
```

This breaks `Inspector.GetQueueInfo()` and the `/api/queues` endpoint in asynqmon, showing "Could not retrieve queues live data" in the UI.

## Changes

- Add nil guards around all three `MEMORY USAGE` calls on task keys (lines 266, 283, 306)
- Add divide-by-zero guard on `agg_task_sample_size` for the aggregation group section

## How to reproduce

This happens when task keys referenced in a queue's pending/active/scheduled/retry lists have expired or been deleted from Redis, but the list entries still reference them. `MEMORY USAGE` on a non-existent key returns nil, which becomes `false` in Lua.

## Testing

Tested in production with Redis 7.2.4 and asynq v0.25.1 worker processing ~900K tasks/day. After applying this patch, the `/api/queues` endpoint returns data correctly.

Fixes #728
Related to #901