### PR TITLE
Add BatchEnqueue for pipelined multi-task enqueue

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -40,6 +40,7 @@ type Task struct {
 func (t *Task) Type() string               { return t.typename }
 func (t *Task) Payload() []byte            { return t.payload }
 func (t *Task) Headers() map[string]string { return t.headers }
+func (t *Task) Options() []Option          { return t.opts }
 
 // ResultWriter returns a pointer to the ResultWriter associated with the task.
 //

--- a/asynq_test.go
+++ b/asynq_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -196,5 +197,32 @@ func TestParseRedisURIErrors(t *testing.T) {
 			t.Errorf("%s: ParseRedisURI(%q) succeeded for malformed input, want error",
 				tc.desc, tc.uri)
 		}
+	}
+}
+
+func TestTaskOptions(t *testing.T) {
+	opts := []Option{
+		MaxRetry(3),
+		Queue("critical"),
+		Timeout(5 * time.Minute),
+	}
+	task := NewTask("mytask", []byte("payload"), opts...)
+
+	got := task.Options()
+	if len(got) != len(opts) {
+		t.Fatalf("task.Options() returned %d options, want %d", len(got), len(opts))
+	}
+	for i, o := range opts {
+		if got[i].String() != o.String() {
+			t.Errorf("task.Options()[%d] = %v, want %v", i, got[i], o)
+		}
+	}
+}
+
+func TestTaskOptionsNil(t *testing.T) {
+	task := NewTask("mytask", []byte("payload"))
+	got := task.Options()
+	if got != nil {
+		t.Errorf("task.Options() = %v, want nil for task with no options", got)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -428,18 +428,23 @@ type BatchEnqueueResult struct {
 
 // BatchEnqueueContext enqueues all given tasks using a single Redis pipeline round-trip.
 // Each task gets its own result so callers can handle partial success.
-// Only immediate-enqueue tasks are supported; scheduled, unique, and group tasks
-// are rejected with an error in the corresponding BatchEnqueueResult.
+// Immediate and scheduled tasks are supported; unique and group tasks are
+// rejected with an error in the corresponding BatchEnqueueResult.
 func (c *Client) BatchEnqueueContext(ctx context.Context, tasks []*Task, opts ...Option) []BatchEnqueueResult {
 	results := make([]BatchEnqueueResult, len(tasks))
 	if len(tasks) == 0 {
 		return results
 	}
 
-	msgs := make([]*base.TaskMessage, 0, len(tasks))
-	msgIndexes := make([]int, 0, len(tasks))
+	type itemMeta struct {
+		state     base.TaskState
+		processAt time.Time
+	}
 
-	now := time.Now()
+	items := make([]base.BatchEnqueueItem, 0, len(tasks))
+	itemIndexes := make([]int, 0, len(tasks))
+	itemMetas := make([]itemMeta, 0, len(tasks))
+
 	for i, task := range tasks {
 		if task == nil {
 			results[i] = BatchEnqueueResult{Err: fmt.Errorf("task cannot be nil")}
@@ -453,10 +458,6 @@ func (c *Client) BatchEnqueueContext(ctx context.Context, tasks []*Task, opts ..
 		opt, err := composeOptions(merged...)
 		if err != nil {
 			results[i] = BatchEnqueueResult{Err: err}
-			continue
-		}
-		if opt.processAt.After(now) {
-			results[i] = BatchEnqueueResult{Err: fmt.Errorf("batch enqueue does not support scheduled tasks")}
 			continue
 		}
 		if opt.group != "" {
@@ -489,24 +490,38 @@ func (c *Client) BatchEnqueueContext(ctx context.Context, tasks []*Task, opts ..
 			Timeout:   int64(timeout.Seconds()),
 			Retention: int64(opt.retention.Seconds()),
 		}
-		msgs = append(msgs, msg)
-		msgIndexes = append(msgIndexes, i)
+
+		now := time.Now()
+		scheduled := opt.processAt.After(now)
+
+		item := base.BatchEnqueueItem{Msg: msg}
+		var meta itemMeta
+		if scheduled {
+			item.ProcessAt = opt.processAt
+			meta = itemMeta{state: base.TaskStateScheduled, processAt: opt.processAt}
+		} else {
+			meta = itemMeta{state: base.TaskStatePending, processAt: now}
+		}
+
+		items = append(items, item)
+		itemIndexes = append(itemIndexes, i)
+		itemMetas = append(itemMetas, meta)
 	}
 
-	if len(msgs) == 0 {
+	if len(items) == 0 {
 		return results
 	}
 
-	_, err := c.broker.BatchEnqueue(ctx, msgs)
+	_, err := c.broker.BatchEnqueue(ctx, items)
 	if err != nil {
-		for _, idx := range msgIndexes {
+		for _, idx := range itemIndexes {
 			results[idx] = BatchEnqueueResult{Err: err}
 		}
 		return results
 	}
 
-	for j, idx := range msgIndexes {
-		info := newTaskInfo(msgs[j], base.TaskStatePending, now, nil)
+	for j, idx := range itemIndexes {
+		info := newTaskInfo(items[j].Msg, itemMetas[j].state, itemMetas[j].processAt, nil)
 		results[idx] = BatchEnqueueResult{TaskInfo: info}
 	}
 	return results

--- a/client.go
+++ b/client.go
@@ -420,6 +420,98 @@ func (c *Client) EnqueueContext(ctx context.Context, task *Task, opts ...Option)
 	return newTaskInfo(msg, state, opt.processAt, nil), nil
 }
 
+// BatchEnqueueResult holds the result of enqueuing a single task within a batch.
+type BatchEnqueueResult struct {
+	TaskInfo *TaskInfo
+	Err      error
+}
+
+// BatchEnqueueContext enqueues all given tasks using a single Redis pipeline round-trip.
+// Each task gets its own result so callers can handle partial success.
+// Only immediate-enqueue tasks are supported; scheduled, unique, and group tasks
+// are rejected with an error in the corresponding BatchEnqueueResult.
+func (c *Client) BatchEnqueueContext(ctx context.Context, tasks []*Task, opts ...Option) []BatchEnqueueResult {
+	results := make([]BatchEnqueueResult, len(tasks))
+	if len(tasks) == 0 {
+		return results
+	}
+
+	msgs := make([]*base.TaskMessage, 0, len(tasks))
+	msgIndexes := make([]int, 0, len(tasks))
+
+	now := time.Now()
+	for i, task := range tasks {
+		if task == nil {
+			results[i] = BatchEnqueueResult{Err: fmt.Errorf("task cannot be nil")}
+			continue
+		}
+		if strings.TrimSpace(task.Type()) == "" {
+			results[i] = BatchEnqueueResult{Err: fmt.Errorf("task typename cannot be empty")}
+			continue
+		}
+		merged := append(task.opts, opts...)
+		opt, err := composeOptions(merged...)
+		if err != nil {
+			results[i] = BatchEnqueueResult{Err: err}
+			continue
+		}
+		if opt.processAt.After(now) {
+			results[i] = BatchEnqueueResult{Err: fmt.Errorf("batch enqueue does not support scheduled tasks")}
+			continue
+		}
+		if opt.group != "" {
+			results[i] = BatchEnqueueResult{Err: fmt.Errorf("batch enqueue does not support group tasks")}
+			continue
+		}
+		if opt.uniqueTTL > 0 {
+			results[i] = BatchEnqueueResult{Err: fmt.Errorf("batch enqueue does not support unique tasks")}
+			continue
+		}
+		deadline := noDeadline
+		if !opt.deadline.IsZero() {
+			deadline = opt.deadline
+		}
+		timeout := noTimeout
+		if opt.timeout != 0 {
+			timeout = opt.timeout
+		}
+		if deadline.Equal(noDeadline) && timeout == noTimeout {
+			timeout = defaultTimeout
+		}
+		msg := &base.TaskMessage{
+			ID:        opt.taskID,
+			Type:      task.Type(),
+			Payload:   task.Payload(),
+			Headers:   task.Headers(),
+			Queue:     opt.queue,
+			Retry:     opt.retry,
+			Deadline:  deadline.Unix(),
+			Timeout:   int64(timeout.Seconds()),
+			Retention: int64(opt.retention.Seconds()),
+		}
+		msgs = append(msgs, msg)
+		msgIndexes = append(msgIndexes, i)
+	}
+
+	if len(msgs) == 0 {
+		return results
+	}
+
+	_, err := c.broker.BatchEnqueue(ctx, msgs)
+	if err != nil {
+		for _, idx := range msgIndexes {
+			results[idx] = BatchEnqueueResult{Err: err}
+		}
+		return results
+	}
+
+	for j, idx := range msgIndexes {
+		info := newTaskInfo(msgs[j], base.TaskStatePending, now, nil)
+		results[idx] = BatchEnqueueResult{TaskInfo: info}
+	}
+	return results
+}
+
 // Ping performs a ping against the redis connection.
 func (c *Client) Ping() error {
 	return c.broker.Ping()

--- a/client.go
+++ b/client.go
@@ -426,10 +426,39 @@ type BatchEnqueueResult struct {
 	Err      error
 }
 
-// BatchEnqueueContext enqueues all given tasks using a single Redis pipeline round-trip.
-// Each task gets its own result so callers can handle partial success.
-// Immediate and scheduled tasks are supported; unique and group tasks are
-// rejected with an error in the corresponding BatchEnqueueResult.
+// BatchEnqueueContext enqueues multiple tasks in a single Redis pipeline round-trip,
+// returning a per-task result slice aligned with the input tasks slice.
+//
+// # Atomicity Guarantees
+//
+// There is no all-or-nothing guarantee across the batch. Each task is executed as
+// an independent Lua script inside a Redis pipeline. Individual scripts are atomic
+// (the existence check, hash write, and list/sorted-set push for one task cannot
+// be partially applied), but the pipeline as a whole is not wrapped in a
+// MULTI/EXEC transaction. This means:
+//
+//   - Partial success is possible: some tasks may be enqueued while others are not.
+//   - A task whose ID already exists in Redis is silently skipped (treated as a
+//     no-op by the Lua script), and its result will still show success.
+//   - If the Redis pipeline call itself fails (e.g. connection lost, context
+//     cancelled), every task that passed client-side validation receives that
+//     error — none of them can be assumed to have been enqueued.
+//
+// # Validation Errors (pre-pipeline)
+//
+// The following are caught before any Redis call and rejected in the
+// corresponding BatchEnqueueResult.Err without affecting other tasks:
+//
+//   - nil task
+//   - empty task type name
+//   - invalid options
+//   - group tasks (not supported in batch mode)
+//   - unique tasks (not supported in batch mode)
+//
+// # Supported Task Types
+//
+// Immediate and scheduled (via [ProcessAt] or [ProcessIn]) tasks are supported.
+// Group and unique tasks are rejected as described above.
 func (c *Client) BatchEnqueueContext(ctx context.Context, tasks []*Task, opts ...Option) []BatchEnqueueResult {
 	results := make([]BatchEnqueueResult, len(tasks))
 	if len(tasks) == 0 {

--- a/client_test.go
+++ b/client_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hibiken/asynq/internal/base"
+	"github.com/hibiken/asynq/internal/rdb"
+	"github.com/hibiken/asynq/internal/testbroker"
 	h "github.com/hibiken/asynq/internal/testutil"
 	"github.com/redis/go-redis/v9"
 )
@@ -1783,5 +1785,87 @@ func TestBatchEnqueueContext_MixedBatch(t *testing.T) {
 	gotScheduled := h.GetScheduledMessages(t, r, "default")
 	if len(gotScheduled) != 1 {
 		t.Errorf("len(scheduled) = %d, want 1", len(gotScheduled))
+	}
+}
+
+func TestBatchEnqueueContext_ValidationErrors(t *testing.T) {
+	setup(t)
+	client := NewClient(getRedisConnOpt(t))
+	defer client.Close()
+
+	tests := []struct {
+		desc  string
+		tasks []*Task
+		opts  []Option
+	}{
+		{
+			desc:  "nil task",
+			tasks: []*Task{nil},
+		},
+		{
+			desc:  "empty task typename",
+			tasks: []*Task{NewTask("", []byte("payload"))},
+		},
+		{
+			desc:  "blank task typename",
+			tasks: []*Task{NewTask("   ", []byte("payload"))},
+		},
+		{
+			desc:  "invalid option: unique TTL less than 1s",
+			tasks: []*Task{NewTask("foo", nil)},
+			opts:  []Option{Unique(300 * time.Millisecond)},
+		},
+		{
+			desc:  "group task rejected",
+			tasks: []*Task{NewTask("foo", nil, Group("mygroup"))},
+		},
+		{
+			desc:  "unique task rejected",
+			tasks: []*Task{NewTask("foo", nil, Unique(time.Hour))},
+		},
+	}
+
+	for _, tc := range tests {
+		results := client.BatchEnqueueContext(context.Background(), tc.tasks, tc.opts...)
+		if len(results) != len(tc.tasks) {
+			t.Errorf("%s: got %d results, want %d", tc.desc, len(results), len(tc.tasks))
+			continue
+		}
+		for i, res := range results {
+			if res.Err == nil {
+				t.Errorf("%s: results[%d].Err = nil, want non-nil error", tc.desc, i)
+			}
+			if res.TaskInfo != nil {
+				t.Errorf("%s: results[%d].TaskInfo = %v, want nil", tc.desc, i, res.TaskInfo)
+			}
+		}
+	}
+}
+
+func TestBatchEnqueueContext_BrokerError(t *testing.T) {
+	r := rdb.NewRDB(setup(t))
+	defer r.Close()
+	testBroker := testbroker.NewTestBroker(r)
+	client := &Client{broker: testBroker, sharedConnection: true}
+
+	tasks := []*Task{
+		NewTask("task1", []byte("p1")),
+		NewTask("task2", []byte("p2")),
+	}
+
+	testBroker.Sleep()
+	results := client.BatchEnqueueContext(context.Background(), tasks)
+	testBroker.Wakeup()
+
+	if len(results) != 2 {
+		t.Fatalf("BatchEnqueueContext returned %d results, want 2", len(results))
+	}
+	for i, res := range results {
+		if res.Err == nil {
+			t.Errorf("results[%d].Err = nil, want non-nil error when broker is down", i)
+		}
+		if res.TaskInfo != nil {
+			t.Errorf("results[%d].TaskInfo = %v, want nil on broker error", i, res.TaskInfo)
+		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1661,3 +1661,127 @@ func TestClientEnqueueWithHeadersAndGroup(t *testing.T) {
 		}
 	}
 }
+
+func TestBatchEnqueueContext_ImmediateTasks(t *testing.T) {
+	r := setup(t)
+	client := NewClient(getRedisConnOpt(t))
+	defer client.Close()
+
+	tasks := []*Task{
+		NewTask("task1", []byte("payload1")),
+		NewTask("task2", []byte("payload2")),
+		NewTask("task3", []byte("payload3")),
+	}
+
+	results := client.BatchEnqueueContext(context.Background(), tasks)
+	if len(results) != 3 {
+		t.Fatalf("BatchEnqueueContext returned %d results, want 3", len(results))
+	}
+	for i, res := range results {
+		if res.Err != nil {
+			t.Errorf("results[%d].Err = %v, want nil", i, res.Err)
+		}
+		if res.TaskInfo == nil {
+			t.Errorf("results[%d].TaskInfo is nil, want non-nil", i)
+			continue
+		}
+		if res.TaskInfo.Queue != "default" {
+			t.Errorf("results[%d].TaskInfo.Queue = %q, want %q", i, res.TaskInfo.Queue, "default")
+		}
+		if res.TaskInfo.State != TaskStatePending {
+			t.Errorf("results[%d].TaskInfo.State = %v, want %v", i, res.TaskInfo.State, TaskStatePending)
+		}
+	}
+
+	gotPending := h.GetPendingMessages(t, r, "default")
+	if len(gotPending) != 3 {
+		t.Errorf("len(pending) = %d, want 3", len(gotPending))
+	}
+}
+
+func TestBatchEnqueueContext_ScheduledTask(t *testing.T) {
+	r := setup(t)
+	client := NewClient(getRedisConnOpt(t))
+	defer client.Close()
+
+	future := time.Now().Add(1 * time.Hour)
+	tasks := []*Task{
+		NewTask("scheduled_task", []byte("payload"), ProcessAt(future)),
+	}
+
+	results := client.BatchEnqueueContext(context.Background(), tasks)
+	if len(results) != 1 {
+		t.Fatalf("BatchEnqueueContext returned %d results, want 1", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("results[0].Err = %v, want nil", results[0].Err)
+	}
+	if results[0].TaskInfo == nil {
+		t.Fatal("results[0].TaskInfo is nil, want non-nil")
+	}
+	if results[0].TaskInfo.State != TaskStateScheduled {
+		t.Errorf("results[0].TaskInfo.State = %v, want %v", results[0].TaskInfo.State, TaskStateScheduled)
+	}
+
+	gotScheduled := h.GetScheduledMessages(t, r, "default")
+	if len(gotScheduled) != 1 {
+		t.Errorf("len(scheduled) = %d, want 1", len(gotScheduled))
+	}
+}
+
+func TestBatchEnqueueContext_MixedBatch(t *testing.T) {
+	r := setup(t)
+	client := NewClient(getRedisConnOpt(t))
+	defer client.Close()
+
+	future := time.Now().Add(1 * time.Hour)
+	tasks := []*Task{
+		NewTask("immediate1", []byte("p1")),
+		NewTask("scheduled1", []byte("p2"), ProcessAt(future)),
+		NewTask("immediate2", []byte("p3")),
+		NewTask("grouped1", []byte("p4"), Group("mygroup")),
+		NewTask("immediate3", []byte("p5")),
+	}
+
+	results := client.BatchEnqueueContext(context.Background(), tasks)
+	if len(results) != 5 {
+		t.Fatalf("BatchEnqueueContext returned %d results, want 5", len(results))
+	}
+
+	// Immediate tasks (indices 0, 2, 4) should succeed with Pending state.
+	for _, idx := range []int{0, 2, 4} {
+		if results[idx].Err != nil {
+			t.Errorf("results[%d].Err = %v, want nil (immediate task)", idx, results[idx].Err)
+		}
+		if results[idx].TaskInfo == nil {
+			t.Errorf("results[%d].TaskInfo is nil, want non-nil", idx)
+			continue
+		}
+		if results[idx].TaskInfo.State != TaskStatePending {
+			t.Errorf("results[%d].TaskInfo.State = %v, want %v", idx, results[idx].TaskInfo.State, TaskStatePending)
+		}
+	}
+
+	// Scheduled task (index 1) should succeed with Scheduled state.
+	if results[1].Err != nil {
+		t.Errorf("results[1].Err = %v, want nil (scheduled task)", results[1].Err)
+	}
+	if results[1].TaskInfo != nil && results[1].TaskInfo.State != TaskStateScheduled {
+		t.Errorf("results[1].TaskInfo.State = %v, want %v", results[1].TaskInfo.State, TaskStateScheduled)
+	}
+
+	// Grouped task (index 3) should be rejected.
+	if results[3].Err == nil {
+		t.Error("results[3].Err is nil, want error for group task")
+	}
+
+	gotPending := h.GetPendingMessages(t, r, "default")
+	if len(gotPending) != 3 {
+		t.Errorf("len(pending) = %d, want 3", len(gotPending))
+	}
+
+	gotScheduled := h.GetScheduledMessages(t, r, "default")
+	if len(gotScheduled) != 1 {
+		t.Errorf("len(scheduled) = %d, want 1", len(gotScheduled))
+	}
+}

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -684,6 +684,14 @@ func (l *Lease) IsValid() bool {
 	return l.expireAt.After(now) || l.expireAt.Equal(now)
 }
 
+// BatchEnqueueItem pairs a task message with optional scheduling metadata for
+// batch enqueue operations. If ProcessAt is zero, the task is enqueued for
+// immediate processing; otherwise it is added to the scheduled set.
+type BatchEnqueueItem struct {
+	Msg       *TaskMessage
+	ProcessAt time.Time // zero value → immediate
+}
+
 // Broker is a message broker that supports operations to manage task queues.
 //
 // See rdb.RDB as a reference implementation.
@@ -692,7 +700,7 @@ type Broker interface {
 	Close() error
 	Enqueue(ctx context.Context, msg *TaskMessage) error
 	EnqueueUnique(ctx context.Context, msg *TaskMessage, ttl time.Duration) error
-	BatchEnqueue(ctx context.Context, msgs []*TaskMessage) (int, error)
+	BatchEnqueue(ctx context.Context, items []BatchEnqueueItem) (int, error)
 	Dequeue(qnames ...string) (*TaskMessage, time.Time, error)
 	Done(ctx context.Context, msg *TaskMessage) error
 	MarkAsComplete(ctx context.Context, msg *TaskMessage) error

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -700,6 +700,11 @@ type Broker interface {
 	Close() error
 	Enqueue(ctx context.Context, msg *TaskMessage) error
 	EnqueueUnique(ctx context.Context, msg *TaskMessage, ttl time.Duration) error
+	// BatchEnqueue enqueues multiple tasks in a single round-trip. It returns the
+	// count of newly enqueued tasks; duplicate IDs are silently skipped. The error
+	// is non-nil only on infrastructure failure (e.g. lost connection), in which
+	// case the count is meaningless. Individual task scripts are atomic but the
+	// batch as a whole is not transactional — partial success is possible.
 	BatchEnqueue(ctx context.Context, items []BatchEnqueueItem) (int, error)
 	Dequeue(qnames ...string) (*TaskMessage, time.Time, error)
 	Done(ctx context.Context, msg *TaskMessage) error

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -692,6 +692,7 @@ type Broker interface {
 	Close() error
 	Enqueue(ctx context.Context, msg *TaskMessage) error
 	EnqueueUnique(ctx context.Context, msg *TaskMessage, ttl time.Duration) error
+	BatchEnqueue(ctx context.Context, msgs []*TaskMessage) (int, error)
 	Dequeue(qnames ...string) (*TaskMessage, time.Time, error)
 	Done(ctx context.Context, msg *TaskMessage) error
 	MarkAsComplete(ctx context.Context, msg *TaskMessage) error

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -143,15 +143,14 @@ func (r *RDB) Enqueue(ctx context.Context, msg *base.TaskMessage) error {
 // Each item is either enqueued immediately (ProcessAt is zero) or added to the
 // scheduled sorted set.
 //
+// WARNING: tasks whose IDs already exist in Redis are silently skipped.
+//
 // The pipeline executes independent Lua scripts per task — there is no
 // MULTI/EXEC wrapping the batch, so individual tasks may succeed or fail
-// independently. A task whose ID already exists in Redis is skipped by the Lua
-// script (returns 0) and does not count toward the returned enqueued total.
-//
-// The returned int is the number of tasks that were actually written to Redis
-// (i.e. whose IDs did not already exist). The returned error is non-nil only
-// when the pipeline call itself fails (network error, context cancellation,
-// etc.), in which case no individual result should be trusted.
+// independently. The returned int is the number of tasks actually written;
+// skipped duplicates do not count. The returned error is non-nil only when the
+// pipeline call itself fails (network error, context cancellation, etc.), in
+// which case no individual result should be trusted.
 //
 // Message encoding errors cause an immediate return before any Redis I/O.
 func (r *RDB) BatchEnqueue(ctx context.Context, items []base.BatchEnqueueItem) (int, error) {

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -139,6 +139,65 @@ func (r *RDB) Enqueue(ctx context.Context, msg *base.TaskMessage) error {
 	return nil
 }
 
+// BatchEnqueue adds all given tasks to their respective pending lists using a
+// single Redis pipeline round-trip. It returns the number of newly enqueued
+// messages (tasks whose IDs already exist in Redis are silently skipped).
+func (r *RDB) BatchEnqueue(ctx context.Context, msgs []*base.TaskMessage) (int, error) {
+	var op errors.Op = "rdb.BatchEnqueue"
+	if len(msgs) == 0 {
+		return 0, nil
+	}
+
+	pipe := r.client.Pipeline()
+
+	// Track which indices in the pipeline correspond to enqueueCmd results vs SADD commands.
+	type cmdIndex struct{ pipeIdx int }
+	scriptCmds := make([]cmdIndex, 0, len(msgs))
+	pipeLen := 0
+
+	now := r.clock.Now().UnixNano()
+
+	for _, msg := range msgs {
+		encoded, err := base.EncodeMessage(msg)
+		if err != nil {
+			return 0, errors.E(op, errors.Unknown, fmt.Sprintf("cannot encode message: %v", err))
+		}
+		if _, found := r.queuesPublished.Load(msg.Queue); !found {
+			pipe.SAdd(ctx, base.AllQueues, msg.Queue)
+			r.queuesPublished.Store(msg.Queue, true)
+			pipeLen++
+		}
+		keys := []string{
+			base.TaskKey(msg.Queue, msg.ID),
+			base.PendingKey(msg.Queue),
+		}
+		argv := []interface{}{encoded, msg.ID, now}
+		enqueueCmd.Run(ctx, pipe, keys, argv...)
+		scriptCmds = append(scriptCmds, cmdIndex{pipeIdx: pipeLen})
+		pipeLen++
+	}
+
+	cmds, err := pipe.Exec(ctx)
+	if err != nil && err != redis.Nil {
+		return 0, errors.E(op, errors.Unknown, fmt.Sprintf("redis pipeline error: %v", err))
+	}
+
+	enqueued := 0
+	for _, sc := range scriptCmds {
+		if sc.pipeIdx >= len(cmds) {
+			continue
+		}
+		res, err := cmds[sc.pipeIdx].(*redis.Cmd).Result()
+		if err != nil {
+			continue
+		}
+		if n, ok := res.(int64); ok && n == 1 {
+			enqueued++
+		}
+	}
+	return enqueued, nil
+}
+
 // enqueueUniqueCmd enqueues the task message if the task is unique.
 //
 // KEYS[1] -> unique key

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -139,22 +139,61 @@ func (r *RDB) Enqueue(ctx context.Context, msg *base.TaskMessage) error {
 	return nil
 }
 
-// BatchEnqueue adds all given tasks to their respective pending lists using a
-// single Redis pipeline round-trip. It returns the number of newly enqueued
-// messages (tasks whose IDs already exist in Redis are silently skipped).
 // BatchEnqueue adds all given tasks to Redis using a single pipeline round-trip.
-// Each item is either enqueued immediately or scheduled based on its ProcessAt field.
+// Each item is either enqueued immediately (ProcessAt is zero) or added to the
+// scheduled sorted set.
+//
+// The pipeline executes independent Lua scripts per task — there is no
+// MULTI/EXEC wrapping the batch, so individual tasks may succeed or fail
+// independently. A task whose ID already exists in Redis is skipped by the Lua
+// script (returns 0) and does not count toward the returned enqueued total.
+//
+// The returned int is the number of tasks that were actually written to Redis
+// (i.e. whose IDs did not already exist). The returned error is non-nil only
+// when the pipeline call itself fails (network error, context cancellation,
+// etc.), in which case no individual result should be trusted.
+//
+// Message encoding errors cause an immediate return before any Redis I/O.
 func (r *RDB) BatchEnqueue(ctx context.Context, items []base.BatchEnqueueItem) (int, error) {
 	var op errors.Op = "rdb.BatchEnqueue"
 	if len(items) == 0 {
 		return 0, nil
 	}
 
+	// Preload Lua scripts so that EVALSHA inside the pipeline does not fail with
+	// NOSCRIPT. Script.Run on a pipeline only sends EVALSHA (unlike non-pipeline
+	// Run which retries with EVAL on NOSCRIPT).
+	needsEnqueue, needsSchedule := false, false
+	for _, item := range items {
+		if item.ProcessAt.IsZero() {
+			needsEnqueue = true
+		} else {
+			needsSchedule = true
+		}
+		if needsEnqueue && needsSchedule {
+			break
+		}
+	}
+	if needsEnqueue {
+		if err := enqueueCmd.Load(ctx, r.client).Err(); err != nil {
+			return 0, errors.E(op, errors.Unknown, fmt.Sprintf("failed to load enqueue script: %v", err))
+		}
+	}
+	if needsSchedule {
+		if err := scheduleCmd.Load(ctx, r.client).Err(); err != nil {
+			return 0, errors.E(op, errors.Unknown, fmt.Sprintf("failed to load schedule script: %v", err))
+		}
+	}
+
 	pipe := r.client.Pipeline()
 
-	type cmdIndex struct{ pipeIdx int }
-	scriptCmds := make([]cmdIndex, 0, len(items))
+	// Track which pipeline slot holds each item's script result.
+	scriptIdxs := make([]int, 0, len(items))
 	pipeLen := 0
+
+	// Track queues we add to AllQueues in this pipeline so we can roll back the
+	// in-memory cache on failure.
+	var newQueues []string
 
 	now := r.clock.Now().UnixNano()
 
@@ -166,6 +205,7 @@ func (r *RDB) BatchEnqueue(ctx context.Context, items []base.BatchEnqueueItem) (
 		if _, found := r.queuesPublished.Load(item.Msg.Queue); !found {
 			pipe.SAdd(ctx, base.AllQueues, item.Msg.Queue)
 			r.queuesPublished.Store(item.Msg.Queue, true)
+			newQueues = append(newQueues, item.Msg.Queue)
 			pipeLen++
 		}
 
@@ -184,21 +224,24 @@ func (r *RDB) BatchEnqueue(ctx context.Context, items []base.BatchEnqueueItem) (
 			argv := []interface{}{encoded, item.ProcessAt.Unix(), item.Msg.ID}
 			scheduleCmd.Run(ctx, pipe, keys, argv...)
 		}
-		scriptCmds = append(scriptCmds, cmdIndex{pipeIdx: pipeLen})
+		scriptIdxs = append(scriptIdxs, pipeLen)
 		pipeLen++
 	}
 
 	cmds, err := pipe.Exec(ctx)
 	if err != nil && err != redis.Nil {
+		for _, q := range newQueues {
+			r.queuesPublished.Delete(q)
+		}
 		return 0, errors.E(op, errors.Unknown, fmt.Sprintf("redis pipeline error: %v", err))
 	}
 
 	enqueued := 0
-	for _, sc := range scriptCmds {
-		if sc.pipeIdx >= len(cmds) {
+	for _, idx := range scriptIdxs {
+		if idx >= len(cmds) {
 			continue
 		}
-		res, err := cmds[sc.pipeIdx].(*redis.Cmd).Result()
+		res, err := cmds[idx].(*redis.Cmd).Result()
 		if err != nil {
 			continue
 		}

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -142,37 +142,48 @@ func (r *RDB) Enqueue(ctx context.Context, msg *base.TaskMessage) error {
 // BatchEnqueue adds all given tasks to their respective pending lists using a
 // single Redis pipeline round-trip. It returns the number of newly enqueued
 // messages (tasks whose IDs already exist in Redis are silently skipped).
-func (r *RDB) BatchEnqueue(ctx context.Context, msgs []*base.TaskMessage) (int, error) {
+// BatchEnqueue adds all given tasks to Redis using a single pipeline round-trip.
+// Each item is either enqueued immediately or scheduled based on its ProcessAt field.
+func (r *RDB) BatchEnqueue(ctx context.Context, items []base.BatchEnqueueItem) (int, error) {
 	var op errors.Op = "rdb.BatchEnqueue"
-	if len(msgs) == 0 {
+	if len(items) == 0 {
 		return 0, nil
 	}
 
 	pipe := r.client.Pipeline()
 
-	// Track which indices in the pipeline correspond to enqueueCmd results vs SADD commands.
 	type cmdIndex struct{ pipeIdx int }
-	scriptCmds := make([]cmdIndex, 0, len(msgs))
+	scriptCmds := make([]cmdIndex, 0, len(items))
 	pipeLen := 0
 
 	now := r.clock.Now().UnixNano()
 
-	for _, msg := range msgs {
-		encoded, err := base.EncodeMessage(msg)
+	for _, item := range items {
+		encoded, err := base.EncodeMessage(item.Msg)
 		if err != nil {
 			return 0, errors.E(op, errors.Unknown, fmt.Sprintf("cannot encode message: %v", err))
 		}
-		if _, found := r.queuesPublished.Load(msg.Queue); !found {
-			pipe.SAdd(ctx, base.AllQueues, msg.Queue)
-			r.queuesPublished.Store(msg.Queue, true)
+		if _, found := r.queuesPublished.Load(item.Msg.Queue); !found {
+			pipe.SAdd(ctx, base.AllQueues, item.Msg.Queue)
+			r.queuesPublished.Store(item.Msg.Queue, true)
 			pipeLen++
 		}
-		keys := []string{
-			base.TaskKey(msg.Queue, msg.ID),
-			base.PendingKey(msg.Queue),
+
+		if item.ProcessAt.IsZero() {
+			keys := []string{
+				base.TaskKey(item.Msg.Queue, item.Msg.ID),
+				base.PendingKey(item.Msg.Queue),
+			}
+			argv := []interface{}{encoded, item.Msg.ID, now}
+			enqueueCmd.Run(ctx, pipe, keys, argv...)
+		} else {
+			keys := []string{
+				base.TaskKey(item.Msg.Queue, item.Msg.ID),
+				base.ScheduledKey(item.Msg.Queue),
+			}
+			argv := []interface{}{encoded, item.ProcessAt.Unix(), item.Msg.ID}
+			scheduleCmd.Run(ctx, pipe, keys, argv...)
 		}
-		argv := []interface{}{encoded, msg.ID, now}
-		enqueueCmd.Run(ctx, pipe, keys, argv...)
 		scriptCmds = append(scriptCmds, cmdIndex{pipeIdx: pipeLen})
 		pipeLen++
 	}

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -160,6 +160,83 @@ func TestEnqueueTaskIdConflictError(t *testing.T) {
 	}
 }
 
+func TestBatchEnqueue(t *testing.T) {
+	r := setup(t)
+	defer r.Close()
+
+	t1 := h.NewTaskMessage("send_email", h.JSON(map[string]interface{}{"to": "user@example.com"}))
+	t2 := h.NewTaskMessageWithQueue("generate_csv", h.JSON(map[string]interface{}{}), "csv")
+	t3 := h.NewTaskMessageWithQueue("sync", nil, "low")
+
+	enqueueTime := time.Now()
+	r.SetClock(timeutil.NewSimulatedClock(enqueueTime))
+
+	t.Run("enqueue multiple tasks", func(t *testing.T) {
+		h.FlushDB(t, r.client)
+		msgs := []*base.TaskMessage{t1, t2, t3}
+
+		n, err := r.BatchEnqueue(context.Background(), msgs)
+		if err != nil {
+			t.Fatalf("BatchEnqueue returned error: %v", err)
+		}
+		if n != 3 {
+			t.Errorf("BatchEnqueue returned %d, want 3", n)
+		}
+
+		for _, msg := range msgs {
+			pendingKey := base.PendingKey(msg.Queue)
+			pendingIDs := r.client.LRange(context.Background(), pendingKey, 0, -1).Val()
+			found := false
+			for _, id := range pendingIDs {
+				if id == msg.ID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("task %s not found in pending list %s", msg.ID, pendingKey)
+			}
+
+			taskKey := base.TaskKey(msg.Queue, msg.ID)
+			state := r.client.HGet(context.Background(), taskKey, "state").Val()
+			if state != "pending" {
+				t.Errorf("state for task %s = %q, want %q", msg.ID, state, "pending")
+			}
+		}
+	})
+
+	t.Run("empty batch", func(t *testing.T) {
+		h.FlushDB(t, r.client)
+
+		n, err := r.BatchEnqueue(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("BatchEnqueue(nil) returned error: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("BatchEnqueue(nil) returned %d, want 0", n)
+		}
+	})
+
+	t.Run("duplicate IDs skipped", func(t *testing.T) {
+		h.FlushDB(t, r.client)
+
+		if err := r.Enqueue(context.Background(), t1); err != nil {
+			t.Fatalf("pre-enqueue failed: %v", err)
+		}
+
+		dup := *t1
+		newMsg := h.NewTaskMessage("new_task", nil)
+
+		n, err := r.BatchEnqueue(context.Background(), []*base.TaskMessage{&dup, newMsg})
+		if err != nil {
+			t.Fatalf("BatchEnqueue returned error: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("BatchEnqueue returned %d, want 1 (duplicate should be skipped)", n)
+		}
+	})
+}
+
 func TestEnqueueQueueCache(t *testing.T) {
 	r := setup(t)
 	defer r.Close()

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -293,6 +293,21 @@ func TestBatchEnqueue(t *testing.T) {
 			t.Errorf("state for scheduled task %s = %q, want %q", s1.ID, state, "scheduled")
 		}
 	})
+
+	t.Run("pipeline error from cancelled context", func(t *testing.T) {
+		h.FlushDB(t, r.client)
+
+		msg := h.NewTaskMessage("pipeline_error_task", nil)
+		items := []base.BatchEnqueueItem{{Msg: msg}}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := r.BatchEnqueue(ctx, items)
+		if err == nil {
+			t.Error("BatchEnqueue with cancelled context returned nil error, want non-nil")
+		}
+	})
 }
 
 func TestEnqueueQueueCache(t *testing.T) {

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -173,9 +173,13 @@ func TestBatchEnqueue(t *testing.T) {
 
 	t.Run("enqueue multiple tasks", func(t *testing.T) {
 		h.FlushDB(t, r.client)
-		msgs := []*base.TaskMessage{t1, t2, t3}
+		items := []base.BatchEnqueueItem{
+			{Msg: t1},
+			{Msg: t2},
+			{Msg: t3},
+		}
 
-		n, err := r.BatchEnqueue(context.Background(), msgs)
+		n, err := r.BatchEnqueue(context.Background(), items)
 		if err != nil {
 			t.Fatalf("BatchEnqueue returned error: %v", err)
 		}
@@ -183,7 +187,8 @@ func TestBatchEnqueue(t *testing.T) {
 			t.Errorf("BatchEnqueue returned %d, want 3", n)
 		}
 
-		for _, msg := range msgs {
+		for _, item := range items {
+			msg := item.Msg
 			pendingKey := base.PendingKey(msg.Queue)
 			pendingIDs := r.client.LRange(context.Background(), pendingKey, 0, -1).Val()
 			found := false
@@ -227,12 +232,65 @@ func TestBatchEnqueue(t *testing.T) {
 		dup := *t1
 		newMsg := h.NewTaskMessage("new_task", nil)
 
-		n, err := r.BatchEnqueue(context.Background(), []*base.TaskMessage{&dup, newMsg})
+		items := []base.BatchEnqueueItem{
+			{Msg: &dup},
+			{Msg: newMsg},
+		}
+		n, err := r.BatchEnqueue(context.Background(), items)
 		if err != nil {
 			t.Fatalf("BatchEnqueue returned error: %v", err)
 		}
 		if n != 1 {
 			t.Errorf("BatchEnqueue returned %d, want 1 (duplicate should be skipped)", n)
+		}
+	})
+
+	t.Run("scheduled tasks", func(t *testing.T) {
+		h.FlushDB(t, r.client)
+
+		future := time.Now().Add(1 * time.Hour)
+		s1 := h.NewTaskMessage("deferred_email", nil)
+		items := []base.BatchEnqueueItem{
+			{Msg: t1},
+			{Msg: s1, ProcessAt: future},
+		}
+
+		n, err := r.BatchEnqueue(context.Background(), items)
+		if err != nil {
+			t.Fatalf("BatchEnqueue returned error: %v", err)
+		}
+		if n != 2 {
+			t.Errorf("BatchEnqueue returned %d, want 2", n)
+		}
+
+		// Immediate task should be in pending.
+		pendingIDs := r.client.LRange(context.Background(), base.PendingKey(t1.Queue), 0, -1).Val()
+		foundPending := false
+		for _, id := range pendingIDs {
+			if id == t1.ID {
+				foundPending = true
+			}
+		}
+		if !foundPending {
+			t.Errorf("immediate task %s not found in pending list", t1.ID)
+		}
+
+		// Scheduled task should be in scheduled set.
+		scheduledIDs := r.client.ZRange(context.Background(), base.ScheduledKey(s1.Queue), 0, -1).Val()
+		foundScheduled := false
+		for _, id := range scheduledIDs {
+			if id == s1.ID {
+				foundScheduled = true
+			}
+		}
+		if !foundScheduled {
+			t.Errorf("scheduled task %s not found in scheduled set", s1.ID)
+		}
+
+		taskKey := base.TaskKey(s1.Queue, s1.ID)
+		state := r.client.HGet(context.Background(), taskKey, "state").Val()
+		if state != "scheduled" {
+			t.Errorf("state for scheduled task %s = %q, want %q", s1.ID, state, "scheduled")
 		}
 	})
 }

--- a/internal/testbroker/testbroker.go
+++ b/internal/testbroker/testbroker.go
@@ -64,6 +64,15 @@ func (tb *TestBroker) EnqueueUnique(ctx context.Context, msg *base.TaskMessage, 
 	return tb.real.EnqueueUnique(ctx, msg, ttl)
 }
 
+func (tb *TestBroker) BatchEnqueue(ctx context.Context, msgs []*base.TaskMessage) (int, error) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	if tb.sleeping {
+		return 0, errRedisDown
+	}
+	return tb.real.BatchEnqueue(ctx, msgs)
+}
+
 func (tb *TestBroker) Dequeue(qnames ...string) (*base.TaskMessage, time.Time, error) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()

--- a/internal/testbroker/testbroker.go
+++ b/internal/testbroker/testbroker.go
@@ -64,13 +64,13 @@ func (tb *TestBroker) EnqueueUnique(ctx context.Context, msg *base.TaskMessage, 
 	return tb.real.EnqueueUnique(ctx, msg, ttl)
 }
 
-func (tb *TestBroker) BatchEnqueue(ctx context.Context, msgs []*base.TaskMessage) (int, error) {
+func (tb *TestBroker) BatchEnqueue(ctx context.Context, items []base.BatchEnqueueItem) (int, error) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 	if tb.sleeping {
 		return 0, errRedisDown
 	}
-	return tb.real.BatchEnqueue(ctx, msgs)
+	return tb.real.BatchEnqueue(ctx, items)
 }
 
 func (tb *TestBroker) Dequeue(qnames ...string) (*base.TaskMessage, time.Time, error) {


### PR DESCRIPTION
Adds BatchEnqueue to the Broker interface and RDB implementation that sends multiple enqueueCmd Lua script invocations in a single Redis pipeline round-trip. Also adds BatchEnqueueContext to the Client as the public API, returning per-task results for partial-success handling.

Ref: hibiken/asynq#1069