### PR TITLE
fix: close pubsub on Receive error to prevent resource leak

### DIFF
--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -1488,6 +1488,7 @@ func (r *RDB) CancelationPubSub() (*redis.PubSub, error) {
 	pubsub := r.client.Subscribe(ctx, base.CancelChannel)
 	_, err := pubsub.Receive(ctx)
 	if err != nil {
+		pubsub.Close()
 		return nil, errors.E(op, errors.Unknown, fmt.Sprintf("redis pubsub receive error: %v", err))
 	}
 	return pubsub, nil


### PR DESCRIPTION
## Summary

Fixes #762

`CancelationPubSub()` in `internal/rdb/rdb.go` creates a Redis PubSub via `r.client.Subscribe()`, then calls `pubsub.Receive()` to confirm the subscription. If `Receive()` returns an error, the function returns `nil` without closing the already-allocated `pubsub` object. This leaks the underlying Redis connection and subscription on every failed attempt.

The caller in `subscriber.go` retries `CancelationPubSub()` in a loop on failure, so each retry iteration that hits this error path leaks another subscription.

## Fix

Added `pubsub.Close()` in the error path before returning, so the Redis subscription is properly released when `Receive()` fails.

## Changes

- `internal/rdb/rdb.go`: Call `pubsub.Close()` before returning the error in `CancelationPubSub()`.

Co-Authored-By: Oz <oz-agent@warp.dev>