### PR TITLE
fix: use configurable timezone for daily stats keys

### DIFF
--- a/inspector.go
+++ b/inspector.go
@@ -45,6 +45,14 @@ func NewInspectorFromRedisClient(c redis.UniversalClient) *Inspector {
 	}
 }
 
+// SetLocation sets the time zone location used by the Inspector to determine
+// the date boundary for daily processed/failed stats queries.
+//
+// By default, the Inspector uses time.UTC.
+func (i *Inspector) SetLocation(loc *time.Location) {
+	i.rdb.SetLocation(loc)
+}
+
 // Close closes the connection with redis.
 func (i *Inspector) Close() error {
 	if i.sharedConnection {

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -3675,3 +3675,18 @@ func TestInspectorGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestInspectorSetLocation(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skip("could not load Asia/Shanghai timezone, skipping")
+	}
+	inspector := NewInspector(getRedisConnOpt(t))
+	defer inspector.Close()
+
+	// Should not panic with a valid location.
+	inspector.SetLocation(loc)
+
+	// Should not panic with nil (falls back to UTC).
+	inspector.SetLocation(nil)
+}

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -167,13 +167,15 @@ func FailedTotalKey(qname string) string {
 }
 
 // ProcessedKey returns a redis key for processed count for the given day for the queue.
+// The caller is responsible for converting t to the desired timezone before calling this function.
 func ProcessedKey(qname string, t time.Time) string {
-	return QueueKeyPrefix(qname) + "processed:" + t.UTC().Format("2006-01-02")
+	return QueueKeyPrefix(qname) + "processed:" + t.Format("2006-01-02")
 }
 
 // FailedKey returns a redis key for failure count for the given day for the queue.
+// The caller is responsible for converting t to the desired timezone before calling this function.
 func FailedKey(qname string, t time.Time) string {
-	return QueueKeyPrefix(qname) + "failed:" + t.UTC().Format("2006-01-02")
+	return QueueKeyPrefix(qname) + "failed:" + t.Format("2006-01-02")
 }
 
 // ServerInfoKey returns a redis key for process info.

--- a/internal/base/base_test.go
+++ b/internal/base/base_test.go
@@ -209,6 +209,10 @@ func TestFailedTotalKey(t *testing.T) {
 }
 
 func TestProcessedKey(t *testing.T) {
+	shanghaiLoc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skip("could not load Asia/Shanghai timezone, skipping")
+	}
 	tests := []struct {
 		qname string
 		input time.Time
@@ -217,6 +221,11 @@ func TestProcessedKey(t *testing.T) {
 		{"default", time.Date(2019, 11, 14, 10, 30, 1, 1, time.UTC), "asynq:{default}:processed:2019-11-14"},
 		{"critical", time.Date(2020, 12, 1, 1, 0, 1, 1, time.UTC), "asynq:{critical}:processed:2020-12-01"},
 		{"default", time.Date(2020, 1, 6, 15, 02, 1, 1, time.UTC), "asynq:{default}:processed:2020-01-06"},
+		// Timezone-aware test: 2024-03-22 07:30 CST = 2024-03-21 23:30 UTC
+		// With the fix, the key should use the local date (03-22), not UTC date (03-21).
+		{"default", time.Date(2024, 3, 22, 7, 30, 0, 0, shanghaiLoc), "asynq:{default}:processed:2024-03-22"},
+		// Edge case: exactly midnight CST = 16:00 previous day UTC
+		{"default", time.Date(2024, 3, 22, 0, 0, 0, 0, shanghaiLoc), "asynq:{default}:processed:2024-03-22"},
 	}
 
 	for _, tc := range tests {
@@ -228,6 +237,10 @@ func TestProcessedKey(t *testing.T) {
 }
 
 func TestFailedKey(t *testing.T) {
+	shanghaiLoc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skip("could not load Asia/Shanghai timezone, skipping")
+	}
 	tests := []struct {
 		qname string
 		input time.Time
@@ -236,6 +249,9 @@ func TestFailedKey(t *testing.T) {
 		{"default", time.Date(2019, 11, 14, 10, 30, 1, 1, time.UTC), "asynq:{default}:failed:2019-11-14"},
 		{"custom", time.Date(2020, 12, 1, 1, 0, 1, 1, time.UTC), "asynq:{custom}:failed:2020-12-01"},
 		{"low", time.Date(2020, 1, 6, 15, 02, 1, 1, time.UTC), "asynq:{low}:failed:2020-01-06"},
+		// Timezone-aware test: 2024-03-22 07:30 CST = 2024-03-21 23:30 UTC
+		// With the fix, the key should use the local date (03-22), not UTC date (03-21).
+		{"default", time.Date(2024, 3, 22, 7, 30, 0, 0, shanghaiLoc), "asynq:{default}:failed:2024-03-22"},
 	}
 
 	for _, tc := range tests {

--- a/internal/rdb/inspect.go
+++ b/internal/rdb/inspect.go
@@ -146,7 +146,7 @@ func (r *RDB) CurrentStats(qname string) (*Stats, error) {
 	if !exists {
 		return nil, errors.E(op, errors.NotFound, &errors.QueueNotFoundError{Queue: qname})
 	}
-	now := r.clock.Now()
+	now := r.clock.Now().In(r.location)
 	keys := []string{
 		base.PendingKey(qname),
 		base.ActiveKey(qname),
@@ -381,7 +381,7 @@ func (r *RDB) HistoricalStats(qname string, n int) ([]*DailyStats, error) {
 		return nil, errors.E(op, errors.NotFound, &errors.QueueNotFoundError{Queue: qname})
 	}
 	const day = 24 * time.Hour
-	now := r.clock.Now().UTC()
+	now := r.clock.Now().In(r.location)
 	var days []time.Time
 	var keys []string
 	for i := 0; i < n; i++ {

--- a/internal/rdb/inspect_test.go
+++ b/internal/rdb/inspect_test.go
@@ -64,7 +64,8 @@ func TestCurrentStats(t *testing.T) {
 	m5 := h.NewTaskMessageBuilder().SetType("important_notification").SetQueue("critical").Build()
 	m6 := h.NewTaskMessageBuilder().SetType("minor_notification").SetQueue("low").Build()
 	m7 := h.NewTaskMessageBuilder().SetType("send_sms").Build()
-	now := time.Now()
+	// CurrentStats uses UTC by default unless SetLocation is called.
+	now := time.Now().UTC()
 	r.SetClock(timeutil.NewSimulatedClock(now))
 
 	tests := []struct {

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -29,14 +29,16 @@ const LeaseDuration = 30 * time.Second
 type RDB struct {
 	client          redis.UniversalClient
 	clock           timeutil.Clock
+	location        *time.Location
 	queuesPublished sync.Map
 }
 
 // NewRDB returns a new instance of RDB.
 func NewRDB(client redis.UniversalClient) *RDB {
 	return &RDB{
-		client: client,
-		clock:  timeutil.NewRealClock(),
+		client:   client,
+		clock:    timeutil.NewRealClock(),
+		location: time.UTC,
 	}
 }
 
@@ -55,6 +57,19 @@ func (r *RDB) Client() redis.UniversalClient {
 // Use this function to set the clock to SimulatedClock in tests.
 func (r *RDB) SetClock(c timeutil.Clock) {
 	r.clock = c
+}
+
+// SetLocation sets the time zone location used by RDB to determine
+// the date boundary for daily processed/failed stats keys.
+//
+// By default, RDB uses time.UTC. Setting this to a different location
+// (e.g., time.Local, or a location loaded via time.LoadLocation("Asia/Shanghai"))
+// will cause daily stats to be aggregated according to that timezone's date boundary.
+func (r *RDB) SetLocation(loc *time.Location) {
+	if loc == nil {
+		loc = time.UTC
+	}
+	r.location = loc
 }
 
 // Ping checks the connection with redis server.
@@ -351,7 +366,7 @@ func (r *RDB) Done(ctx context.Context, msg *base.TaskMessage) error {
 		base.ActiveKey(msg.Queue),
 		base.LeaseKey(msg.Queue),
 		base.TaskKey(msg.Queue, msg.ID),
-		base.ProcessedKey(msg.Queue, now),
+		base.ProcessedKey(msg.Queue, now.In(r.location)),
 		base.ProcessedTotalKey(msg.Queue),
 	}
 	argv := []interface{}{
@@ -459,7 +474,7 @@ func (r *RDB) MarkAsComplete(ctx context.Context, msg *base.TaskMessage) error {
 		base.LeaseKey(msg.Queue),
 		base.CompletedKey(msg.Queue),
 		base.TaskKey(msg.Queue, msg.ID),
-		base.ProcessedKey(msg.Queue, now),
+		base.ProcessedKey(msg.Queue, now.In(r.location)),
 		base.ProcessedTotalKey(msg.Queue),
 	}
 	argv := []interface{}{
@@ -820,8 +835,8 @@ func (r *RDB) Retry(ctx context.Context, msg *base.TaskMessage, processAt time.T
 		base.ActiveKey(msg.Queue),
 		base.LeaseKey(msg.Queue),
 		base.RetryKey(msg.Queue),
-		base.ProcessedKey(msg.Queue, now),
-		base.FailedKey(msg.Queue, now),
+		base.ProcessedKey(msg.Queue, now.In(r.location)),
+		base.FailedKey(msg.Queue, now.In(r.location)),
 		base.ProcessedTotalKey(msg.Queue),
 		base.FailedTotalKey(msg.Queue),
 	}
@@ -920,8 +935,8 @@ func (r *RDB) Archive(ctx context.Context, msg *base.TaskMessage, errMsg string)
 		base.ActiveKey(msg.Queue),
 		base.LeaseKey(msg.Queue),
 		base.ArchivedKey(msg.Queue),
-		base.ProcessedKey(msg.Queue, now),
-		base.FailedKey(msg.Queue, now),
+		base.ProcessedKey(msg.Queue, now.In(r.location)),
+		base.FailedKey(msg.Queue, now.In(r.location)),
 		base.ProcessedTotalKey(msg.Queue),
 		base.FailedTotalKey(msg.Queue),
 		base.TaskKeyPrefix(msg.Queue),

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -62,6 +62,21 @@ func setup(tb testing.TB) (r *RDB) {
 	return r
 }
 
+func TestSetLocation(t *testing.T) {
+	r := setup(t)
+	defer r.Close()
+
+	// Test non-nil location.
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skip("could not load Asia/Shanghai timezone, skipping")
+	}
+	r.SetLocation(loc)
+
+	// Test nil location falls back to UTC.
+	r.SetLocation(nil)
+}
+
 func TestEnqueue(t *testing.T) {
 	r := setup(t)
 	defer r.Close()

--- a/server.go
+++ b/server.go
@@ -252,6 +252,12 @@ type Config struct {
 	// If unset or zero, default batch size of 100 is used.
 	// Make sure to not put a big number as the batch size to prevent a long-running script.
 	JanitorBatchSize int
+
+	// Location specifies the time zone location used by the server to determine
+	// the date boundary for daily processed/failed stats keys.
+	//
+	// If unset or nil, the server uses time.UTC.
+	Location *time.Location
 }
 
 // GroupAggregator aggregates a group of tasks into one before the tasks are passed to the Handler.
@@ -504,6 +510,7 @@ func NewServerFromRedisClient(c redis.UniversalClient, cfg Config) *Server {
 	logger.SetLevel(toInternalLogLevel(loglevel))
 
 	rdb := rdb.NewRDB(c)
+	rdb.SetLocation(cfg.Location)
 	starting := make(chan *workerInfo)
 	finished := make(chan *base.TaskMessage)
 	syncCh := make(chan *syncRequest)

--- a/server_test.go
+++ b/server_test.go
@@ -265,3 +265,16 @@ func TestLogLevel(t *testing.T) {
 		}
 	}
 }
+
+func TestServerWithLocation(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skip("could not load Asia/Shanghai timezone, skipping")
+	}
+	srv := NewServer(getRedisConnOpt(t), Config{
+		Concurrency: 10,
+		LogLevel:    testLogLevel,
+		Location:    loc,
+	})
+	srv.Shutdown()
+}


### PR DESCRIPTION
Fixes #671

## Root Cause

[ProcessedKey()](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/base/base.go:168:0-172:1) and [FailedKey()](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/base/base.go:174:0-178:1) in [internal/base/base.go](cci:7://file:///c:/Users/XioSh/Desktop/career/asynq/internal/base/base.go:0:0-0:0) called `.UTC()` before formatting the date string for Redis keys. For users in UTC+8 (Asia/Shanghai), tasks processed before 08:00 local time would fall on the previous UTC day, causing daily stats mismatch.

## Changes

- Removed `.UTC()` from [ProcessedKey()](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/base/base.go:168:0-172:1) / [FailedKey()](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/base/base.go:174:0-178:1) — the caller now passes time in the desired timezone
- Added `location *time.Location` field to [RDB](cci:2://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/rdb.go:28:0-33:1) struct (defaults to `time.UTC` for backward compatibility)
- Added [SetLocation()](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/rdb.go:61:0-72:1) method on [RDB](cci:2://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/rdb.go:28:0-33:1) for timezone configuration
- Updated all stats-recording methods ([Done](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/base/base.go:697:1-697:50), [MarkAsComplete](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/rdb.go:460:0-492:1), [Retry](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/base/base.go:702:1-702:103), [Archive](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/rdb.go:918:0-953:1)) to convert time to configured location
- Updated [CurrentStats](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/inspect.go:138:0-236:1) and [HistoricalStats](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/inspect.go:361:0-402:1) query methods in [inspect.go](cci:7://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/inspect.go:0:0-0:0)
- Added timezone-specific test cases for `Asia/Shanghai`

## Backward Compatibility

- Default location is `time.UTC` — **no breaking change** for existing users
- Existing Redis keys remain valid
- Users who configure [Location](cci:1://file:///c:/Users/XioSh/Desktop/career/asynq/internal/rdb/rdb.go:61:0-72:1) will start generating timezone-aware stats keys
