### PR TITLE
fix: parse DB number from redis-sentinel URI path

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -471,7 +471,7 @@ func (opt RedisClusterClientOpt) MakeRedisClient() interface{} {
 //	redis://[:password@]host[:port][/dbnumber]
 //	rediss://[:password@]host[:port][/dbnumber]
 //	redis-socket://[:password@]path[?db=dbnumber]
-//	redis-sentinel://[:password@]host1[:port][,host2:[:port]][,hostN:[:port]][?master=masterName]
+//	redis-sentinel://[:password@]host1[:port][,host2:[:port]][,hostN:[:port]][/dbnumber][?master=masterName]
 func ParseRedisURI(uri string) (RedisConnOpt, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
@@ -545,11 +545,20 @@ func parseRedisSocketURI(u *url.URL) (RedisConnOpt, error) {
 func parseRedisSentinelURI(u *url.URL) (RedisConnOpt, error) {
 	addrs := strings.Split(u.Host, ",")
 	master := u.Query().Get("master")
+	var db int
+	var err error
+	if len(u.Path) > 0 {
+		xs := strings.Split(strings.Trim(u.Path, "/"), "/")
+		db, err = strconv.Atoi(xs[0])
+		if err != nil {
+			return nil, fmt.Errorf("asynq: could not parse redis sentinel uri: database number should be the first segment of the path")
+		}
+	}
 	var password string
 	if v, ok := u.User.Password(); ok {
 		password = v
 	}
-	return RedisFailoverClientOpt{MasterName: master, SentinelAddrs: addrs, SentinelPassword: password}, nil
+	return RedisFailoverClientOpt{MasterName: master, SentinelAddrs: addrs, SentinelPassword: password, DB: db}, nil
 }
 
 // ResultWriter is a client interface to write result data for a task.

--- a/asynq_test.go
+++ b/asynq_test.go
@@ -148,6 +148,23 @@ func TestParseRedisURI(t *testing.T) {
 				SentinelPassword: "mypassword",
 			},
 		},
+		{
+			"redis-sentinel://localhost:5000,localhost:5001,localhost:5002/3?master=mymaster",
+			RedisFailoverClientOpt{
+				MasterName:    "mymaster",
+				SentinelAddrs: []string{"localhost:5000", "localhost:5001", "localhost:5002"},
+				DB:            3,
+			},
+		},
+		{
+			"redis-sentinel://:mypassword@localhost:5000,localhost:5001,localhost:5002/7?master=mymaster",
+			RedisFailoverClientOpt{
+				MasterName:       "mymaster",
+				SentinelAddrs:    []string{"localhost:5000", "localhost:5001", "localhost:5002"},
+				SentinelPassword: "mypassword",
+				DB:               7,
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -187,6 +204,10 @@ func TestParseRedisURIErrors(t *testing.T) {
 		{
 			"non integer for db numbers for socket",
 			"redis-socket:///some/path/to/redis?db=one",
+		},
+		{
+			"non integer for db number for sentinel",
+			"redis-sentinel://localhost:5000/abc?master=mymaster",
 		},
 	}
 


### PR DESCRIPTION
fix: parse DB number from redis-sentinel URI path (#669)

Problem

parseRedisSentinelURI ignored the /dbnumber path segment, making it impossible to connect to any DB other than 0 via sentinel URIs. For example:
text
would silently drop the /3 and always use DB 0.

The redis:// and rediss:// schemes already supported this via parseRedisURI.

Changes

•  asynq.go: Extract the DB number from the URI path in parseRedisSentinelURI, using the same strconv.Atoi(xs[0]) pattern as parseRedisURI. Pass the parsed DB into RedisFailoverClientOpt. Return a descriptive error if the path segment is not a valid integer.
•  asynq.go doc comment: Updated the ParseRedisURI godoc to show /dbnumber in the sentinel URI format:
text
•  asynq_test.go: Added test cases:
◦  redis-sentinel://...5002/3?master=mymaster → DB 3
◦  redis-sentinel://:mypassword@...5002/7?master=mymaster → DB 7 with password
◦  redis-sentinel://localhost:5000/abc?master=mymaster → error (non-integer)