### PR TITLE
refactor(cli): migrate commands from Run to RunE and fix group error …

### DIFF
--- a/tools/asynq/cmd/cron.go
+++ b/tools/asynq/cmd/cron.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"time"
 
@@ -36,14 +35,14 @@ var cronListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "List cron entries",
-	Run:     cronList,
+	RunE:    cronList,
 }
 
 var cronHistoryCmd = &cobra.Command{
 	Use:   "history <entry_id> [<entry_id>...]",
 	Short: "Show history of each cron tasks",
 	Args:  cobra.MinimumNArgs(1),
-	Run:   cronHistory,
+	RunE:  cronHistory,
 	Example: heredoc.Doc(`
 		$ asynq cron history 7837f142-6337-4217-9276-8f27281b67d1
 		$ asynq cron history 7837f142-6337-4217-9276-8f27281b67d1 bf6a8594-cd03-4968-b36a-8572c5e160dd
@@ -51,17 +50,16 @@ var cronHistoryCmd = &cobra.Command{
 		$ asynq cron history 7837f142-6337-4217-9276-8f27281b67d1 --page=2`),
 }
 
-func cronList(cmd *cobra.Command, args []string) {
+func cronList(cmd *cobra.Command, args []string) error {
 	inspector := createInspector()
 
 	entries, err := inspector.SchedulerEntries()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return fmt.Errorf("could not fetch scheduler entries: %v", err)
 	}
 	if len(entries) == 0 {
 		fmt.Println("No scheduler entries")
-		return
+		return nil
 	}
 
 	// Sort entries by spec.
@@ -78,6 +76,7 @@ func cronList(cmd *cobra.Command, args []string) {
 		}
 	}
 	printTable(cols, printRows)
+	return nil
 }
 
 // Returns a string describing when the next enqueue will happen.
@@ -97,16 +96,14 @@ func prevEnqueue(prevEnqueuedAt time.Time) string {
 	return fmt.Sprintf("%v ago", time.Since(prevEnqueuedAt).Round(time.Second))
 }
 
-func cronHistory(cmd *cobra.Command, args []string) {
+func cronHistory(cmd *cobra.Command, args []string) error {
 	pageNum, err := cmd.Flags().GetInt("page")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	pageSize, err := cmd.Flags().GetInt("size")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	inspector := createInspector()
 	for i, entryID := range args {
@@ -136,4 +133,5 @@ func cronHistory(cmd *cobra.Command, args []string) {
 		}
 		printTable(cols, printRows)
 	}
+	return nil
 }

--- a/tools/asynq/cmd/dash.go
+++ b/tools/asynq/cmd/dash.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -32,14 +31,14 @@ var dashCmd = &cobra.Command{
 	Example: heredoc.Doc(`
         $ asynq dash
         $ asynq dash --refresh=3s`),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagPollInterval < 1*time.Second {
-			fmt.Println("error: --refresh cannot be less than 1s")
-			os.Exit(1)
+			return fmt.Errorf("--refresh cannot be less than 1s")
 		}
 		dash.Run(dash.Options{
 			PollInterval: flagPollInterval,
 			RedisConnOpt: getRedisConnOpt(),
 		})
+		return nil
 	},
 }

--- a/tools/asynq/cmd/group.go
+++ b/tools/asynq/cmd/group.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
@@ -31,22 +30,25 @@ var groupListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List groups",
 	Args:    cobra.NoArgs,
-	Run:     groupLists,
+	RunE:    groupLists,
 }
 
-func groupLists(cmd *cobra.Command, args []string) {
+func groupLists(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	inspector := createInspector()
 	groups, err := inspector.Groups(qname)
+	if err != nil {
+		return fmt.Errorf("could not fetch groups: %v", err)
+	}
 	if len(groups) == 0 {
 		fmt.Printf("No groups found in queue %q\n", qname)
-		return
+		return nil
 	}
 	for _, g := range groups {
 		fmt.Println(g.Group)
 	}
+	return nil
 }

--- a/tools/asynq/cmd/queue.go
+++ b/tools/asynq/cmd/queue.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/fatih/color"
@@ -44,16 +43,14 @@ var queueListCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "List queues",
 	Aliases: []string{"ls"},
-	// TODO: Use RunE instead?
-	Run: queueList,
+	RunE:    queueList,
 }
 
 var queueInspectCmd = &cobra.Command{
 	Use:   "inspect <queue> [<queue>...]",
 	Short: "Display detailed information on one or more queues",
-	Args:  cobra.MinimumNArgs(1),
-	// TODO: Use RunE instead?
-	Run: queueInspect,
+	Args: cobra.MinimumNArgs(1),
+	RunE: queueInspect,
 	Example: heredoc.Doc(`
 		$ asynq queue inspect myqueue
 		$ asynq queue inspect queue1 queue2 queue3`),
@@ -62,8 +59,8 @@ var queueInspectCmd = &cobra.Command{
 var queueHistoryCmd = &cobra.Command{
 	Use:   "history <queue> [<queue>...]",
 	Short: "Display historical aggregate data from one or more queues",
-	Args:  cobra.MinimumNArgs(1),
-	Run:   queueHistory,
+	Args: cobra.MinimumNArgs(1),
+	RunE: queueHistory,
 	Example: heredoc.Doc(`
 		$ asynq queue history myqueue
 		$ asynq queue history queue1 queue2 queue3
@@ -74,7 +71,7 @@ var queuePauseCmd = &cobra.Command{
 	Use:   "pause <queue> [<queue>...]",
 	Short: "Pause one or more queues",
 	Args:  cobra.MinimumNArgs(1),
-	Run:   queuePause,
+	RunE:  queuePause,
 	Example: heredoc.Doc(`
 		$ asynq queue pause myqueue
 		$ asynq queue pause queue1 queue2 queue3`),
@@ -85,7 +82,7 @@ var queueUnpauseCmd = &cobra.Command{
 	Short:   "Resume (unpause) one or more queues",
 	Args:    cobra.MinimumNArgs(1),
 	Aliases: []string{"unpause"},
-	Run:     queueUnpause,
+	RunE:    queueUnpause,
 	Example: heredoc.Doc(`
 		$ asynq queue resume myqueue
 		$ asynq queue resume queue1 queue2 queue3`),
@@ -96,14 +93,14 @@ var queueRemoveCmd = &cobra.Command{
 	Short:   "Remove one or more queues",
 	Aliases: []string{"rm", "delete"},
 	Args:    cobra.MinimumNArgs(1),
-	Run:     queueRemove,
+	RunE:    queueRemove,
 	Example: heredoc.Doc(`
 		$ asynq queue rm myqueue
 		$ asynq queue rm queue1 queue2 queue3
 		$ asynq queue rm myqueue --force`),
 }
 
-func queueList(cmd *cobra.Command, args []string) {
+func queueList(cmd *cobra.Command, args []string) error {
 	type queueInfo struct {
 		name    string
 		keyslot int64
@@ -112,8 +109,7 @@ func queueList(cmd *cobra.Command, args []string) {
 	inspector := createInspector()
 	queues, err := inspector.Queues()
 	if err != nil {
-		fmt.Printf("error: Could not fetch list of queues: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("could not fetch list of queues: %v", err)
 	}
 	var qs []*queueInfo
 	for _, qname := range queues {
@@ -121,13 +117,13 @@ func queueList(cmd *cobra.Command, args []string) {
 		if useRedisCluster {
 			keyslot, err := inspector.ClusterKeySlot(qname)
 			if err != nil {
-				fmt.Errorf("error: Could not get cluster keyslot for %q\n", qname)
+				fmt.Printf("error: could not get cluster keyslot for %q\n", qname)
 				continue
 			}
 			q.keyslot = keyslot
 			nodes, err := inspector.ClusterNodes(qname)
 			if err != nil {
-				fmt.Errorf("error: Could not get cluster nodes for %q\n", qname)
+				fmt.Printf("error: could not get cluster nodes for %q\n", qname)
 				continue
 			}
 			q.nodes = nodes
@@ -148,9 +144,10 @@ func queueList(cmd *cobra.Command, args []string) {
 			fmt.Println(q.name)
 		}
 	}
+	return nil
 }
 
-func queueInspect(cmd *cobra.Command, args []string) {
+func queueInspect(cmd *cobra.Command, args []string) error {
 	inspector := createInspector()
 	for i, qname := range args {
 		if i > 0 {
@@ -163,6 +160,7 @@ func queueInspect(cmd *cobra.Command, args []string) {
 		}
 		printQueueInfo(info)
 	}
+	return nil
 }
 
 func printQueueInfo(info *asynq.QueueInfo) {
@@ -195,11 +193,10 @@ func printQueueInfo(info *asynq.QueueInfo) {
 	)
 }
 
-func queueHistory(cmd *cobra.Command, args []string) {
+func queueHistory(cmd *cobra.Command, args []string) error {
 	days, err := cmd.Flags().GetInt("days")
 	if err != nil {
-		fmt.Printf("error: Internal error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	inspector := createInspector()
 	for i, qname := range args {
@@ -214,6 +211,7 @@ func queueHistory(cmd *cobra.Command, args []string) {
 		}
 		printDailyStats(stats)
 	}
+	return nil
 }
 
 func printDailyStats(stats []*asynq.DailyStats) {
@@ -233,49 +231,63 @@ func printDailyStats(stats []*asynq.DailyStats) {
 	)
 }
 
-func queuePause(cmd *cobra.Command, args []string) {
+func queuePause(cmd *cobra.Command, args []string) error {
 	inspector := createInspector()
+	var firstErr error
 	for _, qname := range args {
 		err := inspector.PauseQueue(qname)
 		if err != nil {
 			fmt.Println(err)
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
 		fmt.Printf("Successfully paused queue %q\n", qname)
 	}
+	return firstErr
 }
 
-func queueUnpause(cmd *cobra.Command, args []string) {
+func queueUnpause(cmd *cobra.Command, args []string) error {
 	inspector := createInspector()
+	var firstErr error
 	for _, qname := range args {
 		err := inspector.UnpauseQueue(qname)
 		if err != nil {
 			fmt.Println(err)
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
 		fmt.Printf("Successfully unpaused queue %q\n", qname)
 	}
+	return firstErr
 }
 
-func queueRemove(cmd *cobra.Command, args []string) {
+func queueRemove(cmd *cobra.Command, args []string) error {
 	// TODO: Use inspector once RemoveQueue become public API.
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
-		fmt.Printf("error: Internal error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	r := createRDB()
+	var firstErr error
 	for _, qname := range args {
 		err = r.RemoveQueue(qname, force)
 		if err != nil {
 			if errors.IsQueueNotEmpty(err) {
 				fmt.Printf("error: %v\nIf you are sure you want to delete it, run 'asynq queue rm --force %s'\n", err, qname)
-				continue
+			} else {
+				fmt.Printf("error: %v\n", err)
 			}
-			fmt.Printf("error: %v\n", err)
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
 		fmt.Printf("Successfully removed queue %q\n", qname)
 	}
+	return firstErr
 }

--- a/tools/asynq/cmd/root.go
+++ b/tools/asynq/cmd/root.go
@@ -487,35 +487,31 @@ func isPrintable(data []byte) bool {
 }
 
 // Helper to turn a command line flag into a duration
-func getDuration(cmd *cobra.Command, arg string) time.Duration {
+func getDuration(cmd *cobra.Command, arg string) (time.Duration, error) {
 	durationStr, err := cmd.Flags().GetString(arg)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return 0, err
 	}
 
 	duration, err := time.ParseDuration(durationStr)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return 0, err
 	}
 
-	return duration
+	return duration, nil
 }
 
 // Helper to turn a command line flag into a time
-func getTime(cmd *cobra.Command, arg string) time.Time {
+func getTime(cmd *cobra.Command, arg string) (time.Time, error) {
 	timeStr, err := cmd.Flags().GetString(arg)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return time.Time{}, err
 	}
 
 	timeVal, err := time.Parse(time.RFC3339, timeStr)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return time.Time{}, err
 	}
 
-	return timeVal
+	return timeVal, nil
 }

--- a/tools/asynq/cmd/server.go
+++ b/tools/asynq/cmd/server.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -44,20 +43,19 @@ The command shows the following for each server:
 
 A "active" server is pulling tasks from queues and processing them.
 A "stopped" server is no longer pulling new tasks from queues`,
-	Run: serverList,
+	RunE: serverList,
 }
 
-func serverList(cmd *cobra.Command, args []string) {
+func serverList(cmd *cobra.Command, args []string) error {
 	r := createRDB()
 
 	servers, err := r.ListServers()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return fmt.Errorf("could not fetch list of servers: %v", err)
 	}
 	if len(servers) == 0 {
 		fmt.Println("No running servers")
-		return
+		return nil
 	}
 
 	// sort by hostname and pid
@@ -80,6 +78,7 @@ func serverList(cmd *cobra.Command, args []string) {
 		}
 	}
 	printTable(cols, printRows)
+	return nil
 }
 
 func formatQueues(qmap map[string]int) string {

--- a/tools/asynq/cmd/stats.go
+++ b/tools/asynq/cmd/stats.go
@@ -35,7 +35,7 @@ var statsCmd = &cobra.Command{
 	    * Aggregate data for the current day
 	    * Basic information about the running redis instance`),
 	Args: cobra.NoArgs,
-	Run:  stats,
+	RunE: stats,
 }
 
 var jsonFlag bool
@@ -74,13 +74,12 @@ type FullStats struct {
 	RedisInfo  map[string]string `json:"redis"`
 }
 
-func stats(cmd *cobra.Command, args []string) {
+func stats(cmd *cobra.Command, args []string) error {
 	r := createRDB()
 
 	queues, err := r.AllQueues()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return fmt.Errorf("could not fetch queues: %v", err)
 	}
 
 	var aggStats AggregateStats
@@ -88,8 +87,7 @@ func stats(cmd *cobra.Command, args []string) {
 	for _, qname := range queues {
 		s, err := r.CurrentStats(qname)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return fmt.Errorf("could not fetch stats for queue %q: %v", qname, err)
 		}
 		aggStats.Active += s.Active
 		aggStats.Pending += s.Pending
@@ -110,8 +108,7 @@ func stats(cmd *cobra.Command, args []string) {
 		info, err = r.RedisInfo()
 	}
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return fmt.Errorf("could not fetch redis info: %v", err)
 	}
 
 	if jsonFlag {
@@ -122,12 +119,11 @@ func stats(cmd *cobra.Command, args []string) {
 		})
 
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return fmt.Errorf("could not marshal stats to JSON: %v", err)
 		}
 
 		fmt.Println(string(statsJSON))
-		return
+		return nil
 	}
 
 	bold := color.New(color.Bold)
@@ -151,6 +147,7 @@ func stats(cmd *cobra.Command, args []string) {
 		printInfo(info)
 	}
 	fmt.Println()
+	return nil
 }
 
 func printStatsByState(s *AggregateStats) {

--- a/tools/asynq/cmd/task.go
+++ b/tools/asynq/cmd/task.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -120,14 +119,14 @@ var taskListCmd = &cobra.Command{
 		$ asynq task list --queue=myqueue --state=pending
 		$ asynq task list --queue=myqueue --state=aggregating --group=mygroup
 		$ asynq task list --queue=myqueue --state=scheduled --page=2`),
-	Run: taskList,
+	RunE: taskList,
 }
 
 var taskInspectCmd = &cobra.Command{
 	Use:   "inspect --queue=<queue> --id=<task_id>",
 	Short: "Display detailed information on the specified task",
 	Args:  cobra.NoArgs,
-	Run:   taskInspect,
+	RunE:  taskInspect,
 	Example: heredoc.Doc(`
 		$ asynq task inspect --queue=myqueue --id=f1720682-f5a6-4db1-8953-4f48ae541d0f`),
 }
@@ -136,7 +135,7 @@ var taskCancelCmd = &cobra.Command{
 	Use:   "cancel <task_id> [<task_id>...]",
 	Short: "Cancel one or more active tasks",
 	Args:  cobra.MinimumNArgs(1),
-	Run:   taskCancel,
+	RunE:  taskCancel,
 	Example: heredoc.Doc(`
 		$ asynq task cancel f1720682-f5a6-4db1-8953-4f48ae541d0f`),
 }
@@ -145,7 +144,7 @@ var taskArchiveCmd = &cobra.Command{
 	Use:   "archive --queue=<queue> --id=<task_id>",
 	Short: "Archive a task with the given id",
 	Args:  cobra.NoArgs,
-	Run:   taskArchive,
+	RunE:  taskArchive,
 	Example: heredoc.Doc(`
 		$ asynq task archive --queue=myqueue --id=f1720682-f5a6-4db1-8953-4f48ae541d0f`),
 }
@@ -155,7 +154,7 @@ var taskDeleteCmd = &cobra.Command{
 	Aliases: []string{"remove", "rm"},
 	Short:   "Delete a task with the given id",
 	Args:    cobra.NoArgs,
-	Run:     taskDelete,
+	RunE:    taskDelete,
 	Example: heredoc.Doc(`
 		$ asynq task delete --queue=myqueue --id=f1720682-f5a6-4db1-8953-4f48ae541d0f`),
 }
@@ -164,7 +163,7 @@ var taskRunCmd = &cobra.Command{
 	Use:   "run --queue=<queue> --id=<task_id>",
 	Short: "Run a task with the given id",
 	Args:  cobra.NoArgs,
-	Run:   taskRun,
+	RunE:  taskRun,
 	Example: heredoc.Doc(`
 		$ asynq task run --queue=myqueue --id=f1720682-f5a6-4db1-8953-4f48ae541d0f`),
 }
@@ -173,7 +172,7 @@ var taskEnqueueCmd = &cobra.Command{
 	Use:   "enqueue --type_name=footype --payload=barpayload",
 	Short: "Enqueue a task",
 	Args:  cobra.NoArgs,
-	Run:   taskEnqueue,
+	RunE:  taskEnqueue,
 	Example: heredoc.Doc(`
 		$ asynq task enqueue -t footype -l barpayload
 		$ asynq task enqueue -t footask -l barpayload --retry 3 --id f1720682-f5a6-4db1-8953-4f48ae541d0f --queue bazqueue --timeout 100s --deadline 2024-12-14T01:23:45Z --unique 100s --process_at 2024-12-14T01:22:05Z --process_in 100s --retention 5h --group baygroup`),
@@ -183,7 +182,7 @@ var taskArchiveAllCmd = &cobra.Command{
 	Use:   "archiveall --queue=<queue> --state=<state>",
 	Short: "Archive all tasks in the given state",
 	Args:  cobra.NoArgs,
-	Run:   taskArchiveAll,
+	RunE:  taskArchiveAll,
 	Example: heredoc.Doc(`
 		$ asynq task archiveall --queue=myqueue --state=retry
 		$ asynq task archiveall --queue=myqueue --state=aggregating --group=mygroup`),
@@ -193,7 +192,7 @@ var taskDeleteAllCmd = &cobra.Command{
 	Use:   "deleteall --queue=<queue> --state=<state>",
 	Short: "Delete all tasks in the given state",
 	Args:  cobra.NoArgs,
-	Run:   taskDeleteAll,
+	RunE:  taskDeleteAll,
 	Example: heredoc.Doc(`
 		$ asynq task deleteall --queue=myqueue --state=archived
 		$ asynq task deleteall --queue=myqueue --state=aggregating --group=mygroup`),
@@ -203,74 +202,66 @@ var taskRunAllCmd = &cobra.Command{
 	Use:   "runall --queue=<queue> --state=<state>",
 	Short: "Run all tasks in the given state",
 	Args:  cobra.NoArgs,
-	Run:   taskRunAll,
+	RunE:  taskRunAll,
 	Example: heredoc.Doc(`
 		$ asynq task runall --queue=myqueue --state=retry
 		$ asynq task runall --queue=myqueue --state=aggregating --group=mygroup`),
 }
 
-func taskList(cmd *cobra.Command, args []string) {
+func taskList(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	state, err := cmd.Flags().GetString("state")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	pageNum, err := cmd.Flags().GetInt("page")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	pageSize, err := cmd.Flags().GetInt("size")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	switch state {
 	case "active":
-		listActiveTasks(qname, pageNum, pageSize)
+		return listActiveTasks(qname, pageNum, pageSize)
 	case "pending":
-		listPendingTasks(qname, pageNum, pageSize)
+		return listPendingTasks(qname, pageNum, pageSize)
 	case "scheduled":
-		listScheduledTasks(qname, pageNum, pageSize)
+		return listScheduledTasks(qname, pageNum, pageSize)
 	case "retry":
-		listRetryTasks(qname, pageNum, pageSize)
+		return listRetryTasks(qname, pageNum, pageSize)
 	case "archived":
-		listArchivedTasks(qname, pageNum, pageSize)
+		return listArchivedTasks(qname, pageNum, pageSize)
 	case "completed":
-		listCompletedTasks(qname, pageNum, pageSize)
+		return listCompletedTasks(qname, pageNum, pageSize)
 	case "aggregating":
 		group, err := cmd.Flags().GetString("group")
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		if group == "" {
-			fmt.Println("Flag --group is required for listing aggregating tasks")
-			os.Exit(1)
+			return fmt.Errorf("flag --group is required for listing aggregating tasks")
 		}
-		listAggregatingTasks(qname, group, pageNum, pageSize)
+		return listAggregatingTasks(qname, group, pageNum, pageSize)
 	default:
-		fmt.Printf("error: state=%q is not supported\n", state)
-		os.Exit(1)
+		return fmt.Errorf("state=%q is not supported", state)
 	}
 }
 
-func listActiveTasks(qname string, pageNum, pageSize int) {
+func listActiveTasks(qname string, pageNum, pageSize int) error {
 	i := createInspector()
 	tasks, err := i.ListActiveTasks(qname, asynq.PageSize(pageSize), asynq.Page(pageNum))
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	if len(tasks) == 0 {
 		fmt.Printf("No active tasks in %q queue\n", qname)
-		return
+		return nil
 	}
 	printTable(
 		[]string{"ID", "Type", "Payload"},
@@ -280,18 +271,18 @@ func listActiveTasks(qname string, pageNum, pageSize int) {
 			}
 		},
 	)
+	return nil
 }
 
-func listPendingTasks(qname string, pageNum, pageSize int) {
+func listPendingTasks(qname string, pageNum, pageSize int) error {
 	i := createInspector()
 	tasks, err := i.ListPendingTasks(qname, asynq.PageSize(pageSize), asynq.Page(pageNum))
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	if len(tasks) == 0 {
 		fmt.Printf("No pending tasks in %q queue\n", qname)
-		return
+		return nil
 	}
 	printTable(
 		[]string{"ID", "Type", "Payload"},
@@ -301,18 +292,18 @@ func listPendingTasks(qname string, pageNum, pageSize int) {
 			}
 		},
 	)
+	return nil
 }
 
-func listScheduledTasks(qname string, pageNum, pageSize int) {
+func listScheduledTasks(qname string, pageNum, pageSize int) error {
 	i := createInspector()
 	tasks, err := i.ListScheduledTasks(qname, asynq.PageSize(pageSize), asynq.Page(pageNum))
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	if len(tasks) == 0 {
 		fmt.Printf("No scheduled tasks in %q queue\n", qname)
-		return
+		return nil
 	}
 	printTable(
 		[]string{"ID", "Type", "Payload", "Process In"},
@@ -322,6 +313,7 @@ func listScheduledTasks(qname string, pageNum, pageSize int) {
 			}
 		},
 	)
+	return nil
 }
 
 // formatProcessAt formats next process at time to human friendly string.
@@ -335,16 +327,15 @@ func formatProcessAt(processAt time.Time) string {
 	return fmt.Sprintf("in %v", d.Round(time.Second))
 }
 
-func listRetryTasks(qname string, pageNum, pageSize int) {
+func listRetryTasks(qname string, pageNum, pageSize int) error {
 	i := createInspector()
 	tasks, err := i.ListRetryTasks(qname, asynq.PageSize(pageSize), asynq.Page(pageNum))
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	if len(tasks) == 0 {
 		fmt.Printf("No retry tasks in %q queue\n", qname)
-		return
+		return nil
 	}
 	printTable(
 		[]string{"ID", "Type", "Payload", "Next Retry", "Last Error", "Last Failed", "Retried", "Max Retry"},
@@ -355,18 +346,18 @@ func listRetryTasks(qname string, pageNum, pageSize int) {
 			}
 		},
 	)
+	return nil
 }
 
-func listArchivedTasks(qname string, pageNum, pageSize int) {
+func listArchivedTasks(qname string, pageNum, pageSize int) error {
 	i := createInspector()
 	tasks, err := i.ListArchivedTasks(qname, asynq.PageSize(pageSize), asynq.Page(pageNum))
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	if len(tasks) == 0 {
 		fmt.Printf("No archived tasks in %q queue\n", qname)
-		return
+		return nil
 	}
 	printTable(
 		[]string{"ID", "Type", "Payload", "Last Failed", "Last Error"},
@@ -375,18 +366,18 @@ func listArchivedTasks(qname string, pageNum, pageSize int) {
 				fmt.Fprintf(w, tmpl, t.ID, t.Type, sprintBytes(t.Payload), formatPastTime(t.LastFailedAt), t.LastErr)
 			}
 		})
+	return nil
 }
 
-func listCompletedTasks(qname string, pageNum, pageSize int) {
+func listCompletedTasks(qname string, pageNum, pageSize int) error {
 	i := createInspector()
 	tasks, err := i.ListCompletedTasks(qname, asynq.PageSize(pageSize), asynq.Page(pageNum))
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	if len(tasks) == 0 {
 		fmt.Printf("No completed tasks in %q queue\n", qname)
-		return
+		return nil
 	}
 	printTable(
 		[]string{"ID", "Type", "Payload", "CompletedAt", "Result"},
@@ -395,18 +386,18 @@ func listCompletedTasks(qname string, pageNum, pageSize int) {
 				fmt.Fprintf(w, tmpl, t.ID, t.Type, sprintBytes(t.Payload), formatPastTime(t.CompletedAt), sprintBytes(t.Result))
 			}
 		})
+	return nil
 }
 
-func listAggregatingTasks(qname, group string, pageNum, pageSize int) {
+func listAggregatingTasks(qname, group string, pageNum, pageSize int) error {
 	i := createInspector()
 	tasks, err := i.ListAggregatingTasks(qname, group, asynq.PageSize(pageSize), asynq.Page(pageNum))
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	if len(tasks) == 0 {
 		fmt.Printf("No aggregating tasks in group %q \n", group)
-		return
+		return nil
 	}
 	printTable(
 		[]string{"ID", "Type", "Payload", "Group"},
@@ -416,38 +407,42 @@ func listAggregatingTasks(qname, group string, pageNum, pageSize int) {
 			}
 		},
 	)
+	return nil
 }
 
-func taskCancel(cmd *cobra.Command, args []string) {
+func taskCancel(cmd *cobra.Command, args []string) error {
 	i := createInspector()
+	var firstErr error
 	for _, id := range args {
 		if err := i.CancelProcessing(id); err != nil {
 			fmt.Printf("error: could not send cancelation signal: %v\n", err)
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
 		fmt.Printf("Sent cancelation signal for task %s\n", id)
 	}
+	return firstErr
 }
 
-func taskInspect(cmd *cobra.Command, args []string) {
+func taskInspect(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	id, err := cmd.Flags().GetString("id")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	i := createInspector()
 	info, err := i.GetTaskInfo(qname, id)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("could not get task info: %v", err)
 	}
 	printTaskInfo(info)
+	return nil
 }
 
 func printTaskInfo(info *asynq.TaskInfo) {
@@ -486,80 +481,72 @@ func formatPastTime(t time.Time) string {
 	return t.Format(time.UnixDate)
 }
 
-func taskArchive(cmd *cobra.Command, args []string) {
+func taskArchive(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	id, err := cmd.Flags().GetString("id")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	i := createInspector()
 	err = i.ArchiveTask(qname, id)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("could not archive task: %v", err)
 	}
 	fmt.Println("task archived")
+	return nil
 }
 
-func taskDelete(cmd *cobra.Command, args []string) {
+func taskDelete(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	id, err := cmd.Flags().GetString("id")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	i := createInspector()
 	err = i.DeleteTask(qname, id)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("could not delete task: %v", err)
 	}
 	fmt.Println("task deleted")
+	return nil
 }
 
-func taskRun(cmd *cobra.Command, args []string) {
+func taskRun(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	id, err := cmd.Flags().GetString("id")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	i := createInspector()
 	err = i.RunTask(qname, id)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("could not run task: %v", err)
 	}
 	fmt.Println("task is now pending")
+	return nil
 }
 
-func taskEnqueue(cmd *cobra.Command, args []string) {
+func taskEnqueue(cmd *cobra.Command, args []string) error {
 	typeName, err := cmd.Flags().GetString("type_name")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	payload, err := cmd.Flags().GetString("payload")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	// For all of the optional flags, we need to explicitly check whether they were set or
@@ -569,8 +556,7 @@ func taskEnqueue(cmd *cobra.Command, args []string) {
 	if cmd.Flags().Changed("retry") {
 		retry, err := cmd.Flags().GetInt("retry")
 		if err != nil {
-			fmt.Printf("error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		opts = append(opts, asynq.MaxRetry(retry))
 	}
@@ -578,8 +564,7 @@ func taskEnqueue(cmd *cobra.Command, args []string) {
 	if cmd.Flags().Changed("queue") {
 		queue, err := cmd.Flags().GetString("queue")
 		if err != nil {
-			fmt.Printf("error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		opts = append(opts, asynq.Queue(queue))
 	}
@@ -587,41 +572,63 @@ func taskEnqueue(cmd *cobra.Command, args []string) {
 	if cmd.Flags().Changed("id") {
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			fmt.Printf("error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		opts = append(opts, asynq.TaskID(id))
 	}
 
 	if cmd.Flags().Changed("timeout") {
-		opts = append(opts, asynq.Timeout(getDuration(cmd, "timeout")))
+		d, err := getDuration(cmd, "timeout")
+		if err != nil {
+			return err
+		}
+		opts = append(opts, asynq.Timeout(d))
 	}
 
 	if cmd.Flags().Changed("deadline") {
-		opts = append(opts, asynq.Deadline(getTime(cmd, "deadline")))
+		t, err := getTime(cmd, "deadline")
+		if err != nil {
+			return err
+		}
+		opts = append(opts, asynq.Deadline(t))
 	}
 
 	if cmd.Flags().Changed("unique") {
-		opts = append(opts, asynq.Unique(getDuration(cmd, "unique")))
+		d, err := getDuration(cmd, "unique")
+		if err != nil {
+			return err
+		}
+		opts = append(opts, asynq.Unique(d))
 	}
 
 	if cmd.Flags().Changed("process_at") {
-		opts = append(opts, asynq.ProcessAt(getTime(cmd, "process_at")))
+		t, err := getTime(cmd, "process_at")
+		if err != nil {
+			return err
+		}
+		opts = append(opts, asynq.ProcessAt(t))
 	}
 
 	if cmd.Flags().Changed("process_in") {
-		opts = append(opts, asynq.ProcessIn(getDuration(cmd, "process_in")))
+		d, err := getDuration(cmd, "process_in")
+		if err != nil {
+			return err
+		}
+		opts = append(opts, asynq.ProcessIn(d))
 	}
 
 	if cmd.Flags().Changed("retention") {
-		opts = append(opts, asynq.Retention(getDuration(cmd, "retention")))
+		d, err := getDuration(cmd, "retention")
+		if err != nil {
+			return err
+		}
+		opts = append(opts, asynq.Retention(d))
 	}
 
 	if cmd.Flags().Changed("group") {
 		group, err := cmd.Flags().GetString("group")
 		if err != nil {
-			fmt.Printf("error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		opts = append(opts, asynq.Group(group))
 	}
@@ -631,23 +638,21 @@ func taskEnqueue(cmd *cobra.Command, args []string) {
 
 	taskInfo, err := c.Enqueue(task)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("could not enqueue task: %v", err)
 	}
 
 	fmt.Printf("Enqueued task %s to queue %s\n", taskInfo.ID, taskInfo.Queue)
+	return nil
 }
 
-func taskArchiveAll(cmd *cobra.Command, args []string) {
+func taskArchiveAll(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	state, err := cmd.Flags().GetString("state")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	i := createInspector()
@@ -662,35 +667,35 @@ func taskArchiveAll(cmd *cobra.Command, args []string) {
 	case "aggregating":
 		group, err := cmd.Flags().GetString("group")
 		if err != nil {
-			fmt.Printf("error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		if group == "" {
-			fmt.Println("error: Flag --group is required for aggregating tasks")
-			os.Exit(1)
+			return fmt.Errorf("flag --group is required for aggregating tasks")
 		}
 		n, err = i.ArchiveAllAggregatingTasks(qname, group)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%d tasks archived\n", n)
+		return nil
 	default:
-		fmt.Printf("error: unsupported state %q\n", state)
-		os.Exit(1)
+		return fmt.Errorf("unsupported state %q", state)
 	}
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	fmt.Printf("%d tasks archived\n", n)
+	return nil
 }
 
-func taskDeleteAll(cmd *cobra.Command, args []string) {
+func taskDeleteAll(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	state, err := cmd.Flags().GetString("state")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	i := createInspector()
@@ -709,35 +714,35 @@ func taskDeleteAll(cmd *cobra.Command, args []string) {
 	case "aggregating":
 		group, err := cmd.Flags().GetString("group")
 		if err != nil {
-			fmt.Printf("error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		if group == "" {
-			fmt.Println("error: Flag --group is required for aggregating tasks")
-			os.Exit(1)
+			return fmt.Errorf("flag --group is required for aggregating tasks")
 		}
 		n, err = i.DeleteAllAggregatingTasks(qname, group)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%d tasks deleted\n", n)
+		return nil
 	default:
-		fmt.Printf("error: unsupported state %q\n", state)
-		os.Exit(1)
+		return fmt.Errorf("unsupported state %q", state)
 	}
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	fmt.Printf("%d tasks deleted\n", n)
+	return nil
 }
 
-func taskRunAll(cmd *cobra.Command, args []string) {
+func taskRunAll(cmd *cobra.Command, args []string) error {
 	qname, err := cmd.Flags().GetString("queue")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	state, err := cmd.Flags().GetString("state")
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	i := createInspector()
@@ -752,21 +757,23 @@ func taskRunAll(cmd *cobra.Command, args []string) {
 	case "aggregating":
 		group, err := cmd.Flags().GetString("group")
 		if err != nil {
-			fmt.Printf("error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		if group == "" {
-			fmt.Println("error: Flag --group is required for aggregating tasks")
-			os.Exit(1)
+			return fmt.Errorf("flag --group is required for aggregating tasks")
 		}
 		n, err = i.RunAllAggregatingTasks(qname, group)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%d tasks are now pending\n", n)
+		return nil
 	default:
-		fmt.Printf("error: unsupported state %q\n", state)
-		os.Exit(1)
+		return fmt.Errorf("unsupported state %q", state)
 	}
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	fmt.Printf("%d tasks are now pending\n", n)
+	return nil
 }


### PR DESCRIPTION
…handling

Migrate all CLI command handlers from cobra's Run to RunE, replacing fmt.Println(err) + os.Exit(1) patterns with idiomatic error returns. This improves testability and lets cobra handle errors consistently via the existing SilenceUsage/SilenceErrors configuration.

Also refactor getDuration() and getTime() helpers to return errors instead of calling os.Exit(1).

Fix a bug in group.go where the error from inspector.Groups() was never checked, causing silent failures (e.g. on Redis connection errors) to be misreported as "No groups found".