### PR TITLE
Decouple PubSub from Redis in the Broker interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,6 @@ func NewClient(r RedisConnOpt) *Client {
 // NewClientFromRedisClient returns a new instance of Client given a redis.UniversalClient
 // Warning: The underlying redis connection pool will not be closed by Asynq, you are responsible for closing it.
 func NewClientFromRedisClient(c redis.UniversalClient) *Client {
-	// redis.PubSub
 	return &Client{broker: rdb.NewRDB(c), sharedConnection: true}
 }
 

--- a/client.go
+++ b/client.go
@@ -44,6 +44,7 @@ func NewClient(r RedisConnOpt) *Client {
 // NewClientFromRedisClient returns a new instance of Client given a redis.UniversalClient
 // Warning: The underlying redis connection pool will not be closed by Asynq, you are responsible for closing it.
 func NewClientFromRedisClient(c redis.UniversalClient) *Client {
+	// redis.PubSub
 	return &Client{broker: rdb.NewRDB(c), sharedConnection: true}
 }
 

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hibiken/asynq/internal/errors"
 	pb "github.com/hibiken/asynq/internal/proto"
 	"github.com/hibiken/asynq/internal/timeutil"
-	"github.com/redis/go-redis/v9"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -684,6 +683,12 @@ func (l *Lease) IsValid() bool {
 	return l.expireAt.After(now) || l.expireAt.Equal(now)
 }
 
+type PubSub interface {
+	Subscribe(ctx context.Context, channels ...string) error
+	Channel() <-chan string
+	Close() error
+}
+
 // Broker is a message broker that supports operations to manage task queues.
 //
 // See rdb.RDB as a reference implementation.
@@ -723,7 +728,7 @@ type Broker interface {
 	ClearServerState(host string, pid int, serverID string) error
 
 	// Cancelation related methods
-	CancelationPubSub() (*redis.PubSub, error) // TODO: Need to decouple from redis to support other brokers
+	CancelationPubSub() (PubSub, error) // TODO: Need to decouple from redis to support other brokers
 	PublishCancelation(id string) error
 
 	WriteResult(qname, id string, data []byte) (n int, err error)

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -684,7 +684,6 @@ func (l *Lease) IsValid() bool {
 }
 
 type PubSub interface {
-	Subscribe(ctx context.Context, channels ...string) error
 	Channel() <-chan string
 	Close() error
 }

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -728,7 +728,7 @@ type Broker interface {
 	ClearServerState(host string, pid int, serverID string) error
 
 	// Cancelation related methods
-	CancelationPubSub() (PubSub, error) // TODO: Need to decouple from redis to support other brokers
+	CancelationPubSub() (PubSub, error)
 	PublishCancelation(id string) error
 
 	WriteResult(qname, id string, data []byte) (n int, err error)

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -1482,7 +1482,7 @@ func (r *RDB) ClearSchedulerEntries(schedulerID string) error {
 }
 
 // CancelationPubSub returns a pubsub for cancelation messages.
-func (r *RDB) CancelationPubSub() (*redis.PubSub, error) {
+func (r *RDB) CancelationPubSub() (base.PubSub, error) {
 	var op errors.Op = "rdb.CancelationPubSub"
 	ctx := context.Background()
 	pubsub := r.client.Subscribe(ctx, base.CancelChannel)
@@ -1490,7 +1490,8 @@ func (r *RDB) CancelationPubSub() (*redis.PubSub, error) {
 	if err != nil {
 		return nil, errors.E(op, errors.Unknown, fmt.Sprintf("redis pubsub receive error: %v", err))
 	}
-	return pubsub, nil
+
+	return NewRedisPubSub(pubsub), nil
 }
 
 // PublishCancelation publish cancelation message to all subscribers.

--- a/internal/rdb/rdb_pubsub.go
+++ b/internal/rdb/rdb_pubsub.go
@@ -1,0 +1,37 @@
+package rdb
+
+import (
+	"context"
+
+	"github.com/hibiken/asynq/internal/base"
+	"github.com/redis/go-redis/v9"
+)
+
+type RedisPubSub struct {
+	pubsub *redis.PubSub
+}
+
+func NewRedisPubSub(pubsub *redis.PubSub) base.PubSub {
+	return &RedisPubSub{pubsub: pubsub}
+}
+
+func (p *RedisPubSub) Subscribe(ctx context.Context, channels ...string) error {
+	return p.pubsub.Subscribe(ctx, channels...)
+}
+
+func (p *RedisPubSub) Channel() <-chan string {
+	ch := make(chan string)
+
+	go func() {
+		for msg := range p.pubsub.Channel() {
+			ch <- msg.Payload
+		}
+		close(ch)
+	}()
+
+	return ch
+}
+
+func (p *RedisPubSub) Close() error {
+	return p.pubsub.Close()
+}

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -3251,7 +3251,7 @@ func TestCancelationPubSub(t *testing.T) {
 	go func() {
 		for msg := range cancelCh {
 			mu.Lock()
-			received = append(received, msg.Payload)
+			received = append(received, msg)
 			mu.Unlock()
 		}
 	}()

--- a/internal/testbroker/testbroker.go
+++ b/internal/testbroker/testbroker.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq/internal/base"
-	"github.com/redis/go-redis/v9"
 )
 
 var errRedisDown = errors.New("testutil: redis is down")
@@ -190,7 +189,7 @@ func (tb *TestBroker) ClearServerState(host string, pid int, serverID string) er
 	return tb.real.ClearServerState(host, pid, serverID)
 }
 
-func (tb *TestBroker) CancelationPubSub() (*redis.PubSub, error) {
+func (tb *TestBroker) CancelationPubSub() (base.PubSub, error) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 	if tb.sleeping {

--- a/subscriber.go
+++ b/subscriber.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hibiken/asynq/internal/base"
 	"github.com/hibiken/asynq/internal/log"
-	"github.com/redis/go-redis/v9"
 )
 
 type subscriber struct {
@@ -54,7 +53,7 @@ func (s *subscriber) start(wg *sync.WaitGroup) {
 	go func() {
 		defer wg.Done()
 		var (
-			pubsub *redis.PubSub
+			pubsub base.PubSub
 			err    error
 		)
 		// Try until successfully connect to Redis.
@@ -80,7 +79,7 @@ func (s *subscriber) start(wg *sync.WaitGroup) {
 				s.logger.Debug("Subscriber done")
 				return
 			case msg := <-cancelCh:
-				cancel, ok := s.cancelations.Get(msg.Payload)
+				cancel, ok := s.cancelations.Get(msg)
 				if ok {
 					cancel()
 				}


### PR DESCRIPTION
A sub part of #173

## Summary
This change addresses the TODO on `CancelationPubSub()` in Broker interface at `internal/base/base.go:726`.
Removes the hard dependency on `*redis.PubSub` from the Broker interface, replacing it with a minimal `PubSub` interface. This is a prerequisite for supporting non-Redis broker implementations.

# Motivation
`CancelationPubSub()` in the `Broker` interface previously returned `*redis.PubSub` directly, making it impossible to implement a compliant broker without Redis. This change abstracts that dependency behind an interface.

## Changes
### New `base.PubSub` interface

- Defines a broker-agnostic `PubSub` interface with `Channel() <-chan string`, and `Close`
- `Broker.CancelationPubSub()` now returns (PubSub, error) instead of (*redis.PubSub, error)

### New RedisPubSub adapter
- Wraps `*redis.PubSub` to implement `base.PubSub`
- Channel() returns <-chan string (message payloads only), hiding Redis-specific message types from callers
- Updated consumers




## Testing
Existing `TestCancelationPubSub` updated to match the new <-chan string API (reads msg directly instead of msg.Payload).