### PR TITLE
Tune lease recovery timing for faster failover handoff.

### DIFF
--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -23,7 +23,7 @@ import (
 const statsTTL = 90 * 24 * time.Hour // 90 days
 
 // LeaseDuration is the duration used to initially create a lease and to extend it thereafter.
-const LeaseDuration = 30 * time.Second
+const LeaseDuration = 5 * time.Second
 
 // RDB is a client interface to query and mutate task queues.
 type RDB struct {

--- a/recoverer.go
+++ b/recoverer.go
@@ -87,8 +87,8 @@ func (r *recoverer) recover() {
 }
 
 func (r *recoverer) recoverLeaseExpiredTasks() {
-	// Get all tasks which have expired 30 seconds ago or earlier to accommodate certain amount of clock skew.
-	cutoff := time.Now().Add(-30 * time.Second)
+	// Get all tasks which have expired 3 seconds ago or earlier to accommodate certain amount of clock skew.
+	cutoff := time.Now().Add(-3 * time.Second)
 	msgs, err := r.broker.ListLeaseExpired(cutoff, r.queues...)
 	if err != nil {
 		r.logger.Warnf("recoverer: could not list lease expired tasks: %v", err)

--- a/server.go
+++ b/server.go
@@ -518,7 +518,7 @@ func NewServerFromRedisClient(c redis.UniversalClient, cfg Config) *Server {
 	heartbeater := newHeartbeater(heartbeaterParams{
 		logger:         logger,
 		broker:         rdb,
-		interval:       5 * time.Second,
+		interval:       2 * time.Second,
 		concurrency:    n,
 		queues:         queues,
 		strictPriority: cfg.StrictPriority,
@@ -564,7 +564,7 @@ func NewServerFromRedisClient(c redis.UniversalClient, cfg Config) *Server {
 		retryDelayFunc: delayFunc,
 		isFailureFunc:  isFailureFunc,
 		queues:         qnames,
-		interval:       1 * time.Minute,
+		interval:       3 * time.Second,
 	})
 	healthchecker := newHealthChecker(healthcheckerParams{
 		logger:          logger,


### PR DESCRIPTION
Reduce lease duration and recovery intervals so crashed workers are detected and reassigned more quickly during task processing.

Made-with: Cursor