### PR TITLE
Add task lock middleware with optional custom keys

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,6 +60,8 @@ const (
 	TaskIDOpt
 	RetentionOpt
 	GroupOpt
+	LockOpt
+	LockKeyOpt
 )
 
 // Option specifies the task processing behavior.
@@ -86,6 +88,8 @@ type (
 	processInOption time.Duration
 	retentionOption time.Duration
 	groupOption     string
+	lockOption      struct{}
+	lockKeyOption   string
 )
 
 // MaxRetry returns an option to specify the max number of times
@@ -217,6 +221,27 @@ func (name groupOption) String() string     { return fmt.Sprintf("Group(%q)", st
 func (name groupOption) Type() OptionType   { return GroupOpt }
 func (name groupOption) Value() interface{} { return string(name) }
 
+// Lock returns an option to ensure only one worker processes a task delivery at a time.
+// The lock scope is derived from the task type and task ID, and the lock lifetime follows
+// the worker's processing deadline.
+func Lock() Option {
+	return lockOption{}
+}
+
+func (lockOption) String() string     { return "Lock()" }
+func (lockOption) Type() OptionType   { return LockOpt }
+func (lockOption) Value() interface{} { return nil }
+
+// LockKey returns an option to use a custom distributed lock key while processing the task.
+// Providing a custom key also enables locking for the task.
+func LockKey(key string) Option {
+	return lockKeyOption(key)
+}
+
+func (key lockKeyOption) String() string     { return fmt.Sprintf("LockKey(%q)", string(key)) }
+func (key lockKeyOption) Type() OptionType   { return LockKeyOpt }
+func (key lockKeyOption) Value() interface{} { return string(key) }
+
 // ErrDuplicateTask indicates that the given task could not be enqueued since it's a duplicate of another task.
 //
 // ErrDuplicateTask error only applies to tasks enqueued with a Unique option.
@@ -237,6 +262,8 @@ type option struct {
 	processAt time.Time
 	retention time.Duration
 	group     string
+	lock      bool
+	lockKey   string
 }
 
 // composeOptions merges user provided options into the default options
@@ -290,6 +317,15 @@ func composeOptions(opts ...Option) (option, error) {
 				return option{}, errors.New("group key cannot be empty")
 			}
 			res.group = key
+		case lockOption:
+			res.lock = true
+		case lockKeyOption:
+			key := string(opt)
+			if isBlank(key) {
+				return option{}, errors.New("lock key cannot be empty")
+			}
+			res.lock = true
+			res.lockKey = key
 		default:
 			// ignore unexpected option
 		}
@@ -385,7 +421,7 @@ func (c *Client) EnqueueContext(ctx context.Context, task *Task, opts ...Option)
 		ID:        opt.taskID,
 		Type:      task.Type(),
 		Payload:   task.Payload(),
-		Headers:   task.Headers(),
+		Headers:   taskLockHeaders(task.Headers(), opt.lock, opt.lockKey),
 		Queue:     opt.queue,
 		Retry:     opt.retry,
 		Deadline:  deadline.Unix(),

--- a/middleware/task_lock.go
+++ b/middleware/task_lock.go
@@ -1,0 +1,111 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/redis/go-redis/v9"
+)
+
+const defaultTaskLockKeyPrefix = "asynq:lock:"
+
+// TaskLock returns middleware that honors the asynq.Lock option configured on a task.
+func TaskLock(r asynq.RedisConnOpt) asynq.MiddlewareFunc {
+	rc, ok := r.MakeRedisClient().(redis.UniversalClient)
+	if !ok {
+		panic(fmt.Sprintf("asynq/middleware: unsupported RedisConnOpt type %T", r))
+	}
+	return TaskLockFromRedisClient(rc)
+}
+
+// TaskLockFromRedisClient returns middleware that honors the asynq.Lock option configured on a task.
+func TaskLockFromRedisClient(c redis.UniversalClient) asynq.MiddlewareFunc {
+	m := &taskLockMiddleware{client: c}
+	return m.wrap
+}
+
+type taskLockMiddleware struct {
+	client redis.UniversalClient
+}
+
+type taskLockConfig struct {
+	key   string
+	token string
+	ttl   time.Duration
+}
+
+var releaseTaskLockCmd = redis.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	return redis.call("DEL", KEYS[1])
+end
+return 0
+`)
+
+func (m *taskLockMiddleware) wrap(next asynq.Handler) asynq.Handler {
+	return asynq.HandlerFunc(func(ctx context.Context, task *asynq.Task) error {
+		cfg, ok, err := taskLockConfigFromTask(ctx, task)
+		if err != nil || !ok {
+			if err != nil {
+				return err
+			}
+			return next.ProcessTask(ctx, task)
+		}
+
+		acquired, err := m.acquire(ctx, cfg.key, cfg.token, cfg.ttl)
+		if err != nil {
+			return err
+		}
+		if !acquired {
+			return fmt.Errorf("task lock busy for key %q: %w", cfg.key, asynq.RevokeTask)
+		}
+		defer m.release(cfg.key, cfg.token)
+		return next.ProcessTask(ctx, task)
+	})
+}
+
+func (m *taskLockMiddleware) acquire(ctx context.Context, key, token string, ttl time.Duration) (bool, error) {
+	ok, err := m.client.SetNX(ctx, key, token, ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("asynq/middleware: acquire task lock: %w", err)
+	}
+	return ok, nil
+}
+
+func (m *taskLockMiddleware) release(key, token string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = releaseTaskLockCmd.Run(ctx, m.client, []string{key}, token).Err()
+}
+
+func taskLockConfigFromTask(ctx context.Context, task *asynq.Task) (cfg taskLockConfig, ok bool, err error) {
+	headers := task.Headers()
+	if len(headers) == 0 || headers[asynq.TaskLockHeader] != "1" {
+		return taskLockConfig{}, false, nil
+	}
+	taskID, ok := asynq.GetTaskID(ctx)
+	if !ok {
+		return taskLockConfig{}, false, fmt.Errorf("asynq/middleware: task lock requires task ID in context")
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return taskLockConfig{}, false, fmt.Errorf("asynq/middleware: task lock requires context deadline")
+	}
+	ttl := time.Until(deadline)
+	if ttl <= 0 {
+		return taskLockConfig{}, false, fmt.Errorf("asynq/middleware: task lock deadline already expired")
+	}
+
+	lockKey := headers[asynq.TaskLockKeyHeader]
+	if strings.TrimSpace(lockKey) == "" {
+		lockKey = "task:" + task.Type() + ":" + taskID
+	}
+	lockKey = defaultTaskLockKeyPrefix + lockKey
+	return taskLockConfig{
+		key:   lockKey,
+		token: taskID,
+		ttl:   ttl,
+	}, true, nil
+}

--- a/middleware/task_lock_test.go
+++ b/middleware/task_lock_test.go
@@ -1,0 +1,255 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/hibiken/asynq/internal/base"
+	asynqcontext "github.com/hibiken/asynq/internal/context"
+	h "github.com/hibiken/asynq/internal/testutil"
+	"github.com/redis/go-redis/v9"
+)
+
+var (
+	redisAddr string
+	redisDB   int
+
+	useRedisCluster   bool
+	redisClusterAddrs string
+)
+
+func init() {
+	flag.StringVar(&redisAddr, "redis_addr", "localhost:6379", "redis address to use in testing")
+	flag.IntVar(&redisDB, "redis_db", 14, "redis db number to use in testing")
+	flag.BoolVar(&useRedisCluster, "redis_cluster", false, "use redis cluster as a broker in testing")
+	flag.StringVar(&redisClusterAddrs, "redis_cluster_addrs", "localhost:7000,localhost:7001,localhost:7002", "comma separated list of redis server addresses")
+}
+
+func setup(tb testing.TB) redis.UniversalClient {
+	tb.Helper()
+	if useRedisCluster {
+		addrs := strings.Split(redisClusterAddrs, ",")
+		if len(addrs) == 0 {
+			tb.Fatal("No redis cluster addresses provided. Please set addresses using --redis_cluster_addrs flag.")
+		}
+		r := redis.NewClusterClient(&redis.ClusterOptions{Addrs: addrs})
+		h.FlushDB(tb, r)
+		return r
+	}
+	r := redis.NewClient(&redis.Options{Addr: redisAddr, DB: redisDB})
+	h.FlushDB(tb, r)
+	return r
+}
+
+func getRedisConnOpt(tb testing.TB) asynq.RedisConnOpt {
+	tb.Helper()
+	if useRedisCluster {
+		addrs := strings.Split(redisClusterAddrs, ",")
+		if len(addrs) == 0 {
+			tb.Fatal("No redis cluster addresses provided. Please set addresses using --redis_cluster_addrs flag.")
+		}
+		return asynq.RedisClusterClientOpt{Addrs: addrs}
+	}
+	return asynq.RedisClientOpt{Addr: redisAddr, DB: redisDB}
+}
+
+func TestTaskLockBusySkipsHandler(t *testing.T) {
+	rc := setup(t)
+	defer rc.Close()
+
+	taskID := "task-1"
+	lockKey := "asynq:lock:task:email:send:" + taskID
+	if ok, err := rc.SetNX(context.Background(), lockKey, "other-worker", 5*time.Second).Result(); err != nil || !ok {
+		t.Fatalf("rc.SetNX(%q) = (%v, %v), want (true, nil)", lockKey, ok, err)
+	}
+
+	task := asynq.NewTaskWithHeaders("email:send", nil, map[string]string{asynq.TaskLockHeader: "1"})
+	ctx, cancel := asynqcontext.New(context.Background(), &base.TaskMessage{
+		ID:    taskID,
+		Type:  task.Type(),
+		Queue: base.DefaultQueueName,
+	}, time.Now().Add(30*time.Second))
+	defer cancel()
+
+	var called bool
+	handler := asynq.HandlerFunc(func(ctx context.Context, task *asynq.Task) error {
+		called = true
+		return nil
+	})
+
+	err := TaskLockFromRedisClient(rc)(handler).ProcessTask(ctx, task)
+	if !errors.Is(err, asynq.RevokeTask) {
+		t.Fatalf("ProcessTask error = %v, want error wrapping %v", err, asynq.RevokeTask)
+	}
+	if called {
+		t.Fatal("handler was called while task lock was held")
+	}
+}
+
+func TestTaskLockDropsDuplicateDelivery(t *testing.T) {
+	opt := getRedisConnOpt(t)
+	rc := setup(t)
+	defer rc.Close()
+
+	lockKey := "asynq:lock:task:email:welcome:task-1"
+	if ok, err := rc.SetNX(context.Background(), lockKey, "other-worker", 5*time.Second).Result(); err != nil || !ok {
+		t.Fatalf("rc.SetNX(%q) = (%v, %v), want (true, nil)", lockKey, ok, err)
+	}
+
+	var (
+		mu        sync.Mutex
+		processed int
+	)
+	done := make(chan struct{}, 1)
+
+	mux := asynq.NewServeMux()
+	mux.Use(TaskLock(opt))
+	mux.HandleFunc("email:welcome", func(ctx context.Context, task *asynq.Task) error {
+		mu.Lock()
+		processed++
+		mu.Unlock()
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+
+	srv := asynq.NewServer(opt, asynq.Config{
+		Concurrency:              1,
+		LogLevel:                 asynq.FatalLevel,
+		DelayedTaskCheckInterval: 100 * time.Millisecond,
+	})
+	defer srv.Shutdown()
+	if err := srv.Start(mux); err != nil {
+		t.Fatalf("srv.Start() returned error: %v", err)
+	}
+
+	client := asynq.NewClient(opt)
+	defer client.Close()
+	inspector := asynq.NewInspector(opt)
+	defer inspector.Close()
+
+	task := asynq.NewTask("email:welcome", nil, asynq.Lock(), asynq.Retention(time.Minute), asynq.MaxRetry(5))
+	if _, err := client.Enqueue(task, asynq.TaskID("task-1")); err != nil {
+		t.Fatalf("client.Enqueue returned error: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		qinfo, err := inspector.GetQueueInfo(base.DefaultQueueName)
+		if err == nil && qinfo.Size == 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	mu.Lock()
+	if processed != 0 {
+		t.Fatalf("processed = %d, want 0 while lock is busy", processed)
+	}
+	mu.Unlock()
+
+	select {
+	case <-done:
+		t.Fatal("handler should not run when duplicate delivery is locked")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	qinfo, err := inspector.GetQueueInfo(base.DefaultQueueName)
+	if err != nil {
+		t.Fatalf("inspector.GetQueueInfo returned error: %v", err)
+	}
+	if qinfo.Retry != 0 {
+		t.Fatalf("retry task count = %d, want 0", qinfo.Retry)
+	}
+	if qinfo.Archived != 0 {
+		t.Fatalf("archived task count = %d, want 0", qinfo.Archived)
+	}
+	if qinfo.Active != 0 || qinfo.Pending != 0 {
+		t.Fatalf("queue still has active=%d pending=%d, want both zero", qinfo.Active, qinfo.Pending)
+	}
+}
+
+func TestTaskLockAllowsNormalProcessing(t *testing.T) {
+	opt := getRedisConnOpt(t)
+	rc := setup(t)
+	defer rc.Close()
+
+	done := make(chan struct{}, 1)
+	mux := asynq.NewServeMux()
+	mux.Use(TaskLock(opt))
+	mux.HandleFunc("email:welcome", func(ctx context.Context, task *asynq.Task) error {
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+
+	srv := asynq.NewServer(opt, asynq.Config{Concurrency: 1, LogLevel: asynq.FatalLevel})
+	defer srv.Shutdown()
+	if err := srv.Start(mux); err != nil {
+		t.Fatalf("srv.Start() returned error: %v", err)
+	}
+
+	client := asynq.NewClient(opt)
+	defer client.Close()
+	if _, err := client.Enqueue(asynq.NewTask("email:welcome", nil, asynq.Lock()), asynq.TaskID("task-1")); err != nil {
+		t.Fatalf("client.Enqueue returned error: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(4 * time.Second):
+		t.Fatal("timed out waiting for task to be processed")
+	}
+}
+
+func TestTaskLockUsesCustomKey(t *testing.T) {
+	opt := getRedisConnOpt(t)
+	rc := setup(t)
+	defer rc.Close()
+
+	lockKey := "asynq:lock:payment:123"
+	if ok, err := rc.SetNX(context.Background(), lockKey, "other-worker", 5*time.Second).Result(); err != nil || !ok {
+		t.Fatalf("rc.SetNX(%q) = (%v, %v), want (true, nil)", lockKey, ok, err)
+	}
+
+	var called bool
+	mux := asynq.NewServeMux()
+	mux.Use(TaskLock(opt))
+	mux.HandleFunc("payments:charge", func(ctx context.Context, task *asynq.Task) error {
+		called = true
+		return nil
+	})
+
+	srv := asynq.NewServer(opt, asynq.Config{
+		Concurrency:              1,
+		LogLevel:                 asynq.FatalLevel,
+		DelayedTaskCheckInterval: 100 * time.Millisecond,
+	})
+	defer srv.Shutdown()
+	if err := srv.Start(mux); err != nil {
+		t.Fatalf("srv.Start() returned error: %v", err)
+	}
+
+	client := asynq.NewClient(opt)
+	defer client.Close()
+	task := asynq.NewTask("payments:charge", nil, asynq.LockKey("payment:123"))
+	if _, err := client.Enqueue(task, asynq.TaskID("task-1")); err != nil {
+		t.Fatalf("client.Enqueue returned error: %v", err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	if called {
+		t.Fatal("handler was called while custom lock key was held")
+	}
+}

--- a/task_lock_option.go
+++ b/task_lock_option.go
@@ -1,0 +1,31 @@
+package asynq
+
+const taskLockHeader = "asynq_lock"
+const taskLockKeyHeader = "asynq_lock_key"
+
+// TaskLockHeader is the internal task header used to signal that a task should
+// acquire a distributed processing lock before the handler runs.
+const TaskLockHeader = taskLockHeader
+
+// TaskLockKeyHeader is the internal task header used to store a custom
+// distributed lock key for the task.
+const TaskLockKeyHeader = taskLockKeyHeader
+
+func taskLockHeaders(taskHeaders map[string]string, enabled bool, lockKey string) map[string]string {
+	if len(taskHeaders) == 0 && !enabled {
+		return taskHeaders
+	}
+
+	headers := make(map[string]string, len(taskHeaders)+2)
+	for k, v := range taskHeaders {
+		headers[k] = v
+	}
+	if !enabled {
+		return headers
+	}
+	headers[taskLockHeader] = "1"
+	if lockKey != "" {
+		headers[taskLockKeyHeader] = lockKey
+	}
+	return headers
+}


### PR DESCRIPTION
## Summary
- add `Lock()` and `LockKey()` task options so tasks can opt into worker-side distributed locking
- introduce a reusable `middleware.TaskLock(...)` package that enforces processing locks using Redis
- add focused tests covering duplicate delivery revocation, normal processing, and custom lock keys

## Test plan
- [x] `go test ./... -run 'TestTaskLock|TestClientEnqueueWithHeaders'`
- [ ] Manual verification if needed


Made with [Cursor](https://cursor.com)