### PR TITLE
recover from panics in user-provided callbacks

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -6,6 +6,7 @@ package asynq
 
 import (
 	"context"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -158,7 +159,10 @@ func (a *aggregator) aggregate(t time.Time) {
 			for i, m := range msgs {
 				tasks[i] = NewTaskWithHeaders(m.Type, m.Payload, m.Headers)
 			}
-			aggregatedTask := a.ga.Aggregate(gname, tasks)
+			aggregatedTask, ok := a.runAggregate(gname, tasks)
+			if !ok {
+				continue
+			}
 			ctx, cancel := context.WithDeadline(context.Background(), deadline)
 			if _, err := a.client.EnqueueContext(ctx, aggregatedTask, Queue(qname)); err != nil {
 				a.logger.Errorf("Failed to enqueue aggregated task (queue=%q, group=%q, setID=%q): %v",
@@ -173,4 +177,19 @@ func (a *aggregator) aggregate(t time.Time) {
 			cancel()
 		}
 	}
+}
+
+// runAggregate invokes the user-provided GroupAggregator.Aggregate and
+// recovers from any panic so a buggy aggregator doesn't tear down the
+// worker process. Returns the aggregated task and true on success, or
+// the zero value and false on panic.
+func (a *aggregator) runAggregate(group string, tasks []*Task) (aggregated *Task, ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			a.logger.Errorf("recovered from panic in GroupAggregator.Aggregate (group=%q): %v\n%s",
+				group, r, debug.Stack())
+			ok = false
+		}
+	}()
+	return a.ga.Aggregate(group, tasks), true
 }

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -72,9 +73,22 @@ func (hc *healthchecker) start(wg *sync.WaitGroup) {
 				return
 			case <-timer.C:
 				err := hc.broker.Ping()
-				hc.healthcheckFunc(err)
+				hc.runHealthcheckFunc(err)
 				timer.Reset(hc.interval)
 			}
 		}
 	}()
+}
+
+// runHealthcheckFunc invokes the user-provided HealthCheckFunc and
+// recovers from any panic so a buggy callback doesn't tear down the
+// worker process. The processor takes the same precaution for task
+// handlers; this brings the other user-facing callbacks in line.
+func (hc *healthchecker) runHealthcheckFunc(err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			hc.logger.Errorf("recovered from panic in HealthCheckFunc: %v\n%s", r, debug.Stack())
+		}
+	}()
+	hc.healthcheckFunc(err)
 }

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -54,6 +54,24 @@ func TestHealthChecker(t *testing.T) {
 	hc.shutdown()
 }
 
+// Regression for #1132. A panic inside the user-supplied HealthCheckFunc
+// used to take down the entire worker process. runHealthcheckFunc now
+// swallows the panic so the goroutine keeps polling.
+func TestHealthChecker_RecoversFromPanicInUserCallback(t *testing.T) {
+	hc := &healthchecker{
+		logger: testLogger,
+		healthcheckFunc: func(error) {
+			panic("boom from HealthCheckFunc")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic leaked out of runHealthcheckFunc: %v", r)
+		}
+	}()
+	hc.runHealthcheckFunc(nil)
+}
+
 func TestHealthCheckerWhenRedisDown(t *testing.T) {
 	// Make sure that healthchecker goroutine doesn't panic
 	// if it cannot connect to redis.

--- a/periodic_task_manager.go
+++ b/periodic_task_manager.go
@@ -7,6 +7,7 @@ package asynq
 import (
 	"crypto/sha256"
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
@@ -205,7 +206,7 @@ func (mgr *PeriodicTaskManager) remove(removed map[string]string) {
 }
 
 func (mgr *PeriodicTaskManager) sync() {
-	configs, err := mgr.p.GetConfigs()
+	configs, err := mgr.runGetConfigs()
 	if err != nil {
 		mgr.s.logger.Errorf("Failed to get periodic task configs: %v", err)
 		return
@@ -221,6 +222,20 @@ func (mgr *PeriodicTaskManager) sync() {
 	added := mgr.diffAdded(configs)
 	mgr.remove(removed)
 	mgr.add(added)
+}
+
+// runGetConfigs invokes the user-provided PeriodicTaskConfigProvider
+// and recovers from any panic so a buggy provider doesn't tear down
+// the worker process.
+func (mgr *PeriodicTaskManager) runGetConfigs() (configs []*PeriodicTaskConfig, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			mgr.s.logger.Errorf("recovered from panic in PeriodicTaskConfigProvider.GetConfigs: %v\n%s",
+				r, debug.Stack())
+			err = fmt.Errorf("panic in GetConfigs: %v", r)
+		}
+	}()
+	return mgr.p.GetConfigs()
 }
 
 // diffRemoved diffs the incoming configs with the registered config and returns


### PR DESCRIPTION
Fixes #1132.

\`HealthCheckFunc\`, \`GroupAggregator.Aggregate\`, and \`PeriodicTaskConfigProvider.GetConfigs\` all run inside library-owned goroutines. A panic in any of them used to crash the worker process and lose every in-flight task. \`processor.perform\` already takes the same precaution for task handlers; this brings the other user-facing callbacks in line.

Each callsite goes through a small wrapper that defers \`recover\`, logs the panic with a stack, and lets the goroutine carry on:
- HealthCheckFunc → continues, polls again next interval
- GroupAggregator.Aggregate → skips the current group and moves on
- PeriodicTaskConfigProvider.GetConfigs → surfaces a synthetic error so \`sync()\` logs and retries on the next tick

Added \`TestHealthChecker_RecoversFromPanicInUserCallback\` as a no-redis regression covering the wrapper for HealthCheckFunc. The aggregator and periodic-task-manager wrappers follow the same pattern.