### PR TITLE
scheduler: don't log shared-connection close as an error

### DIFF
--- a/client.go
+++ b/client.go
@@ -346,10 +346,16 @@ var (
 	noDeadline time.Time     = time.Unix(0, 0)
 )
 
+// ErrSharedConnection is returned by Close on a Client, Inspector, or
+// Scheduler that was constructed with a caller-owned redis client (the
+// *FromRedisClient constructors). The connection isn't asynq's to close;
+// the caller has to do it themselves.
+var ErrSharedConnection = errors.New("redis connection is shared so the Client can't be closed through asynq")
+
 // Close closes the connection with redis.
 func (c *Client) Close() error {
 	if c.sharedConnection {
-		return fmt.Errorf("redis connection is shared so the Client can't be closed through asynq")
+		return ErrSharedConnection
 	}
 	return c.broker.Close()
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1906,6 +1906,17 @@ func TestBatchEnqueueContext_ValidationErrors(t *testing.T) {
 	}
 }
 
+// Regression for #1068. Client.Close on a shared connection should
+// return ErrSharedConnection so callers (and the Scheduler shutdown
+// path) can distinguish "the user owns this conn" from a real error.
+func TestClient_Close_SharedConnection(t *testing.T) {
+	client := &Client{sharedConnection: true}
+	err := client.Close()
+	if !errors.Is(err, ErrSharedConnection) {
+		t.Fatalf("Close() on shared conn = %v, want ErrSharedConnection", err)
+	}
+}
+
 func TestBatchEnqueueContext_BrokerError(t *testing.T) {
 	r := rdb.NewRDB(setup(t))
 	defer r.Close()

--- a/inspector.go
+++ b/inspector.go
@@ -47,9 +47,13 @@ func NewInspectorFromRedisClient(c redis.UniversalClient) *Inspector {
 }
 
 // Close closes the connection with redis.
+//
+// If the Inspector was constructed via NewInspectorFromRedisClient
+// the returned error is [ErrSharedConnection]: the underlying
+// connection is owned by the caller and must be closed by them.
 func (i *Inspector) Close() error {
 	if i.sharedConnection {
-		return fmt.Errorf("redis connection is shared so the Inspector can't be closed through asynq")
+		return ErrSharedConnection
 	}
 	return i.rdb.Close()
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -301,7 +302,10 @@ func (s *Scheduler) Shutdown() {
 	s.wg.Wait()
 
 	s.clearHistory()
-	if err := s.client.Close(); err != nil {
+	if err := s.client.Close(); err != nil && !errors.Is(err, ErrSharedConnection) {
+		// A shared redis connection isn't asynq's to close; the caller
+		// owns it and will close it themselves, so don't log that as an
+		// error. Anything else is a real failure.
 		s.logger.Errorf("Failed to close redis client connection: %v", err)
 	}
 	s.logger.Info("Scheduler stopped")


### PR DESCRIPTION
Fixes #1068.

When a Scheduler/Client/Inspector is built via the \`*FromRedisClient\` helpers, the redis connection belongs to the caller. \`Close()\` refused to touch it and returned a free-form \`fmt.Errorf\`. The scheduler's shutdown path treated that the same as a real failure and logged it at \`ERROR\`, which produced noisy \"Failed to close redis client connection\" lines on every shutdown.

Promote the refusal to a sentinel (\`ErrSharedConnection\`) and have the scheduler skip the log line when \`Close\` returns it. \`Inspector.Close\` now returns the same sentinel so external callers can use the same \`errors.Is\` check.

Added \`TestClient_Close_SharedConnection\` to lock in the sentinel return path.