### PR TITLE
Augment logger to be structured

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -85,7 +85,7 @@ func (a *aggregator) shutdown() {
 	if a.ga == nil {
 		return
 	}
-	a.logger.Debug("Aggregator shutting down...")
+	a.logger.DebugContext(context.Background(), "Aggregator shutting down", "component", "aggregator")
 	// Signal the aggregator goroutine to stop.
 	a.done <- struct{}{}
 }
@@ -101,12 +101,12 @@ func (a *aggregator) start(wg *sync.WaitGroup) {
 		for {
 			select {
 			case <-a.done:
-				a.logger.Debug("Waiting for all aggregation checks to finish...")
+				a.logger.DebugContext(context.Background(), "Waiting for all aggregation checks to finish", "component", "aggregator")
 				// block until all aggregation checks released the token
 				for i := 0; i < cap(a.sema); i++ {
 					a.sema <- struct{}{}
 				}
-				a.logger.Debug("Aggregator done")
+				a.logger.DebugContext(context.Background(), "Aggregator done", "component", "aggregator")
 				ticker.Stop()
 				return
 			case t := <-ticker.C:
@@ -123,7 +123,7 @@ func (a *aggregator) exec(t time.Time) {
 	default:
 		// If the semaphore blocks, then we are currently running max number of
 		// aggregation checks. Skip this round and log warning.
-		a.logger.Warnf("Max number of aggregation checks in flight. Skipping")
+		a.logger.WarnContext(context.Background(), "Max number of aggregation checks in flight. Skipping", "component", "aggregator")
 	}
 }
 
@@ -132,26 +132,26 @@ func (a *aggregator) aggregate(t time.Time) {
 	for _, qname := range a.queues {
 		groups, err := a.broker.ListGroups(qname)
 		if err != nil {
-			a.logger.Errorf("Failed to list groups in queue: %q", qname)
+			a.logger.ErrorContext(context.Background(), "Failed to list groups in queue", "component", "aggregator", "queue", qname)
 			continue
 		}
 		for _, gname := range groups {
 			aggregationSetID, err := a.broker.AggregationCheck(
 				qname, gname, t, a.gracePeriod, a.maxDelay, a.maxSize)
 			if err != nil {
-				a.logger.Errorf("Failed to run aggregation check: queue=%q group=%q", qname, gname)
+				a.logger.ErrorContext(context.Background(), "Failed to run aggregation check", "component", "aggregator", "queue", qname, "group", gname)
 				continue
 			}
 			if aggregationSetID == "" {
-				a.logger.Debugf("No aggregation needed at this time: queue=%q group=%q", qname, gname)
+				a.logger.DebugContext(context.Background(), "No aggregation needed at this time", "component", "aggregator", "queue", qname, "group", gname)
 				continue
 			}
 
 			// Aggregate and enqueue.
 			msgs, deadline, err := a.broker.ReadAggregationSet(qname, gname, aggregationSetID)
 			if err != nil {
-				a.logger.Errorf("Failed to read aggregation set: queue=%q, group=%q, setID=%q",
-					qname, gname, aggregationSetID)
+				a.logger.ErrorContext(context.Background(), "Failed to read aggregation set",
+					"component", "aggregator", "queue", qname, "group", gname, "set_id", aggregationSetID)
 				continue
 			}
 			tasks := make([]*Task, len(msgs))
@@ -161,14 +161,14 @@ func (a *aggregator) aggregate(t time.Time) {
 			aggregatedTask := a.ga.Aggregate(gname, tasks)
 			ctx, cancel := context.WithDeadline(context.Background(), deadline)
 			if _, err := a.client.EnqueueContext(ctx, aggregatedTask, Queue(qname)); err != nil {
-				a.logger.Errorf("Failed to enqueue aggregated task (queue=%q, group=%q, setID=%q): %v",
-					qname, gname, aggregationSetID, err)
+				a.logger.ErrorContext(ctx, "Failed to enqueue aggregated task",
+					"component", "aggregator", "queue", qname, "group", gname, "set_id", aggregationSetID, "error", err)
 				cancel()
 				continue
 			}
 			if err := a.broker.DeleteAggregationSet(ctx, qname, gname, aggregationSetID); err != nil {
-				a.logger.Warnf("Failed to delete aggregation set: queue=%q, group=%q, setID=%q",
-					qname, gname, aggregationSetID)
+				a.logger.WarnContext(ctx, "Failed to delete aggregation set",
+					"component", "aggregator", "queue", qname, "group", gname, "set_id", aggregationSetID)
 			}
 			cancel()
 		}

--- a/example_test.go
+++ b/example_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"time"
@@ -78,6 +79,25 @@ func ExampleServer_Stop() {
 	}
 
 	srv.Shutdown()
+}
+
+func ExampleWithStructuredLogger() {
+	cfg := asynq.Config{
+		Concurrency: 10,
+		LogLevel:    asynq.InfoLevel,
+	}
+	asynq.WithStructuredLogger(slog.Default())(&cfg)
+
+	srv := asynq.NewServer(
+		asynq.RedisClientOpt{Addr: ":6379"},
+		cfg,
+	)
+
+	h := asynq.NewServeMux()
+	// ... Register handlers
+
+	_ = srv
+	_ = h
 }
 
 func ExampleScheduler() {

--- a/forwarder.go
+++ b/forwarder.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -46,7 +47,7 @@ func newForwarder(params forwarderParams) *forwarder {
 }
 
 func (f *forwarder) shutdown() {
-	f.logger.Debug("Forwarder shutting down...")
+	f.logger.DebugContext(context.Background(), "Forwarder shutting down", "component", "forwarder")
 	// Signal the forwarder goroutine to stop polling.
 	f.done <- struct{}{}
 }
@@ -60,7 +61,7 @@ func (f *forwarder) start(wg *sync.WaitGroup) {
 		for {
 			select {
 			case <-f.done:
-				f.logger.Debug("Forwarder done")
+				f.logger.DebugContext(context.Background(), "Forwarder done", "component", "forwarder")
 				return
 			case <-timer.C:
 				f.exec()
@@ -72,6 +73,6 @@ func (f *forwarder) start(wg *sync.WaitGroup) {
 
 func (f *forwarder) exec() {
 	if err := f.broker.ForwardIfReady(f.queues...); err != nil {
-		f.logger.Errorf("Failed to forward scheduled tasks: %v", err)
+		f.logger.ErrorContext(context.Background(), "Failed to forward scheduled tasks", "component", "forwarder", "error", err)
 	}
 }

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -50,7 +51,7 @@ func (hc *healthchecker) shutdown() {
 		return
 	}
 
-	hc.logger.Debug("Healthchecker shutting down...")
+	hc.logger.DebugContext(context.Background(), "Healthchecker shutting down", "component", "healthchecker")
 	// Signal the healthchecker goroutine to stop.
 	hc.done <- struct{}{}
 }
@@ -67,7 +68,7 @@ func (hc *healthchecker) start(wg *sync.WaitGroup) {
 		for {
 			select {
 			case <-hc.done:
-				hc.logger.Debug("Healthchecker done")
+				hc.logger.DebugContext(context.Background(), "Healthchecker done", "component", "healthchecker")
 				timer.Stop()
 				return
 			case <-timer.C:

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"os"
 	"sync"
 	"time"
@@ -90,7 +91,7 @@ func newHeartbeater(params heartbeaterParams) *heartbeater {
 }
 
 func (h *heartbeater) shutdown() {
-	h.logger.Debug("Heartbeater shutting down...")
+	h.logger.DebugContext(context.Background(), "Heartbeater shutting down", "component", "heartbeater")
 	// Signal the heartbeater goroutine to stop.
 	h.done <- struct{}{}
 }
@@ -121,9 +122,9 @@ func (h *heartbeater) start(wg *sync.WaitGroup) {
 			select {
 			case <-h.done:
 				if err := h.broker.ClearServerState(h.host, h.pid, h.serverID); err != nil {
-					h.logger.Errorf("Failed to clear server state: %v", err)
+					h.logger.ErrorContext(context.Background(), "Failed to clear server state", "component", "heartbeater", "error", err)
 				}
-				h.logger.Debug("Heartbeater done")
+				h.logger.DebugContext(context.Background(), "Heartbeater done", "component", "heartbeater")
 				timer.Stop()
 				return
 
@@ -184,18 +185,18 @@ func (h *heartbeater) beat() {
 	// Note: Set TTL to be long enough so that it won't expire before we write again
 	// and short enough to expire quickly once the process is shut down or killed.
 	if err := h.broker.WriteServerState(&info, ws, h.interval*2); err != nil {
-		h.logger.Errorf("Failed to write server state data: %v", err)
+		h.logger.ErrorContext(context.Background(), "Failed to write server state data", "component", "heartbeater", "error", err)
 	}
 
 	for qname, ids := range idsByQueue {
 		expirationTime, err := h.broker.ExtendLease(qname, ids...)
 		if err != nil {
-			h.logger.Errorf("Failed to extend lease for tasks %v: %v", ids, err)
+			h.logger.ErrorContext(context.Background(), "Failed to extend lease for tasks", "component", "heartbeater", "task_ids", ids, "error", err)
 			continue
 		}
 		for _, id := range ids {
 			if l := h.workers[id].lease; !l.Reset(expirationTime) {
-				h.logger.Warnf("Lease reset failed for %s; lease deadline: %v", id, l.Deadline())
+				h.logger.WarnContext(context.Background(), "Lease reset failed", "component", "heartbeater", "task_id", id, "lease_deadline", l.Deadline())
 			}
 		}
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -6,6 +6,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -90,6 +91,7 @@ func NewLogger(base Base) *Logger {
 // Logger logs message to io.Writer at various log levels.
 type Logger struct {
 	base Base
+	slog *slogLogger
 
 	mu sync.Mutex
 	// Minimum log level for this logger.
@@ -149,6 +151,10 @@ func (l *Logger) canLogAt(v Level) bool {
 }
 
 func (l *Logger) Debug(args ...interface{}) {
+	if l.slog != nil {
+		l.slog.log(context.Background(), DebugLevel, fmt.Sprint(args...), nil)
+		return
+	}
 	if !l.canLogAt(DebugLevel) {
 		return
 	}
@@ -156,6 +162,10 @@ func (l *Logger) Debug(args ...interface{}) {
 }
 
 func (l *Logger) Info(args ...interface{}) {
+	if l.slog != nil {
+		l.slog.log(context.Background(), InfoLevel, fmt.Sprint(args...), nil)
+		return
+	}
 	if !l.canLogAt(InfoLevel) {
 		return
 	}
@@ -163,6 +173,10 @@ func (l *Logger) Info(args ...interface{}) {
 }
 
 func (l *Logger) Warn(args ...interface{}) {
+	if l.slog != nil {
+		l.slog.log(context.Background(), WarnLevel, fmt.Sprint(args...), nil)
+		return
+	}
 	if !l.canLogAt(WarnLevel) {
 		return
 	}
@@ -170,6 +184,10 @@ func (l *Logger) Warn(args ...interface{}) {
 }
 
 func (l *Logger) Error(args ...interface{}) {
+	if l.slog != nil {
+		l.slog.log(context.Background(), ErrorLevel, fmt.Sprint(args...), nil)
+		return
+	}
 	if !l.canLogAt(ErrorLevel) {
 		return
 	}
@@ -177,6 +195,11 @@ func (l *Logger) Error(args ...interface{}) {
 }
 
 func (l *Logger) Fatal(args ...interface{}) {
+	if l.slog != nil {
+		l.slog.log(context.Background(), FatalLevel, fmt.Sprint(args...), nil)
+		os.Exit(1)
+		return
+	}
 	if !l.canLogAt(FatalLevel) {
 		return
 	}

--- a/internal/log/slog.go
+++ b/internal/log/slog.go
@@ -1,0 +1,145 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	asynqcontext "github.com/hibiken/asynq/internal/context"
+)
+
+type slogLogger struct {
+	logger *slog.Logger
+	parent *Logger
+}
+
+// NewStructuredLogger creates a Logger that writes using log/slog.
+func NewStructuredLogger(l *slog.Logger, level Level) *Logger {
+	if l == nil {
+		l = slog.Default()
+	}
+	parent := &Logger{level: level}
+	parent.slog = &slogLogger{logger: l, parent: parent}
+	return parent
+}
+
+func (l *Logger) DebugContext(ctx context.Context, msg string, args ...any) {
+	l.logContext(ctx, DebugLevel, msg, args...)
+}
+
+func (l *Logger) InfoContext(ctx context.Context, msg string, args ...any) {
+	l.logContext(ctx, InfoLevel, msg, args...)
+}
+
+func (l *Logger) WarnContext(ctx context.Context, msg string, args ...any) {
+	l.logContext(ctx, WarnLevel, msg, args...)
+}
+
+func (l *Logger) ErrorContext(ctx context.Context, msg string, args ...any) {
+	l.logContext(ctx, ErrorLevel, msg, args...)
+}
+
+func (l *Logger) logContext(ctx context.Context, level Level, msg string, args ...any) {
+	if l.slog != nil {
+		l.slog.log(ctx, level, msg, args)
+		return
+	}
+	if !l.canLogAt(level) {
+		return
+	}
+	formatted := formatLegacyMessage(msg, args...)
+	switch level {
+	case DebugLevel:
+		l.base.Debug(formatted)
+	case InfoLevel:
+		l.base.Info(formatted)
+	case WarnLevel:
+		l.base.Warn(formatted)
+	case ErrorLevel, FatalLevel:
+		l.base.Error(formatted)
+	}
+}
+
+func (s *slogLogger) log(ctx context.Context, level Level, msg string, args []any) {
+	if !s.parent.canLogAt(level) {
+		return
+	}
+	attrs := taskAttrs(ctx)
+	if len(args) > 0 {
+		attrs = append(attrs, args...)
+	}
+	switch level {
+	case DebugLevel:
+		s.logger.DebugContext(ctx, msg, attrs...)
+	case InfoLevel:
+		s.logger.InfoContext(ctx, msg, attrs...)
+	case WarnLevel:
+		s.logger.WarnContext(ctx, msg, attrs...)
+	case ErrorLevel:
+		s.logger.ErrorContext(ctx, msg, attrs...)
+	case FatalLevel:
+		s.logger.ErrorContext(ctx, msg, attrs...)
+		os.Exit(1)
+	}
+}
+
+func taskAttrs(ctx context.Context) []any {
+	var attrs []any
+	if id, ok := asynqcontext.GetTaskID(ctx); ok {
+		attrs = append(attrs, "task_id", id)
+	}
+	if qname, ok := asynqcontext.GetQueueName(ctx); ok {
+		attrs = append(attrs, "queue", qname)
+	}
+	if n, ok := asynqcontext.GetRetryCount(ctx); ok {
+		attrs = append(attrs, "retry_count", n)
+	}
+	if n, ok := asynqcontext.GetMaxRetry(ctx); ok {
+		attrs = append(attrs, "max_retry", n)
+	}
+	return attrs
+}
+
+func formatLegacyMessage(msg string, args ...any) string {
+	if len(args) == 0 {
+		return msg
+	}
+	// Treat args as alternating key-value pairs when possible for legacy path.
+	if len(args)%2 == 0 {
+		var b string
+		b = msg
+		for i := 0; i < len(args); i += 2 {
+			b += " " + sprintPair(args[i], args[i+1])
+		}
+		return b
+	}
+	return msg + " " + sprintArgs(args...)
+}
+
+func sprintPair(k, v any) string {
+	return sprintArgs(k) + "=" + sprintArgs(v)
+}
+
+func sprintArgs(v ...any) string {
+	switch len(v) {
+	case 0:
+		return ""
+	case 1:
+		return fmtSprint(v[0])
+	default:
+		var s strings.Builder
+		for i, a := range v {
+			if i > 0 {
+				s.WriteString(" ")
+			}
+			s.WriteString(fmtSprint(a))
+		}
+		return s.String()
+	}
+}
+
+func fmtSprint(v any) string {
+	return fmt.Sprint(v)
+}

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -81,3 +81,225 @@ func TestLegacyLoggerContextFallback(t *testing.T) {
 		t.Errorf("got %q, want message with key=value", got)
 	}
 }
+
+func TestStructuredLoggerWarnAndErrorContext(t *testing.T) {
+	tests := []struct {
+		name string
+		log  func(*Logger)
+		want string
+	}{
+		{
+			name: "WarnContext",
+			log: func(l *Logger) {
+				l.WarnContext(context.Background(), "warn msg", "component", "test")
+			},
+			want: "warn msg",
+		},
+		{
+			name: "ErrorContext",
+			log: func(l *Logger) {
+				l.ErrorContext(context.Background(), "error msg", "component", "test")
+			},
+			want: "error msg",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			logger := NewStructuredLogger(slog.New(h), DebugLevel)
+
+			tc.log(logger)
+
+			rec := parseJSONLog(t, buf.Bytes())
+			if rec["msg"] != tc.want {
+				t.Errorf("msg = %v, want %q", rec["msg"], tc.want)
+			}
+			if rec["component"] != "test" {
+				t.Errorf("component = %v, want test", rec["component"])
+			}
+		})
+	}
+}
+
+func TestStructuredLoggerNonContextMethods(t *testing.T) {
+	tests := []struct {
+		name string
+		log  func(*Logger)
+		want string
+	}{
+		{
+			name: "Debug",
+			log:  func(l *Logger) { l.Debug("debug msg") },
+			want: "debug msg",
+		},
+		{
+			name: "Info",
+			log:  func(l *Logger) { l.Info("info msg") },
+			want: "info msg",
+		},
+		{
+			name: "Warn",
+			log:  func(l *Logger) { l.Warn("warn msg") },
+			want: "warn msg",
+		},
+		{
+			name: "Error",
+			log:  func(l *Logger) { l.Error("error msg") },
+			want: "error msg",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			logger := NewStructuredLogger(slog.New(h), DebugLevel)
+
+			tc.log(logger)
+
+			rec := parseJSONLog(t, buf.Bytes())
+			if rec["msg"] != tc.want {
+				t.Errorf("msg = %v, want %q", rec["msg"], tc.want)
+			}
+		})
+	}
+}
+
+func TestNewStructuredLoggerNilUsesDefault(t *testing.T) {
+	logger := NewStructuredLogger(nil, InfoLevel)
+	if logger == nil || logger.slog == nil {
+		t.Fatal("expected structured logger with default slog backend")
+	}
+}
+
+func TestStructuredLoggerTaskAttrsRetryFields(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := NewStructuredLogger(slog.New(h), DebugLevel)
+
+	msg := &base.TaskMessage{
+		ID:      "task-456",
+		Queue:   "critical",
+		Retry:   5,
+		Retried: 2,
+	}
+	ctx, cancel := asynqcontext.New(context.Background(), msg, time.Now().Add(time.Minute))
+	defer cancel()
+
+	logger.InfoContext(ctx, "retrying")
+
+	rec := parseJSONLog(t, buf.Bytes())
+	if rec["task_id"] != "task-456" {
+		t.Errorf("task_id = %v, want task-456", rec["task_id"])
+	}
+	if rec["queue"] != "critical" {
+		t.Errorf("queue = %v, want critical", rec["queue"])
+	}
+	if rec["retry_count"] != float64(2) {
+		t.Errorf("retry_count = %v, want 2", rec["retry_count"])
+	}
+	if rec["max_retry"] != float64(5) {
+		t.Errorf("max_retry = %v, want 5", rec["max_retry"])
+	}
+}
+
+func TestLegacyLoggerContextLevels(t *testing.T) {
+	tests := []struct {
+		name       string
+		log        func(*Logger)
+		wantSubstr string
+	}{
+		{
+			name: "WarnContext",
+			log: func(l *Logger) {
+				l.WarnContext(context.Background(), "warn", "k", "v")
+			},
+			wantSubstr: "WARN: warn k=v",
+		},
+		{
+			name: "ErrorContext",
+			log: func(l *Logger) {
+				l.ErrorContext(context.Background(), "err", "k", "v")
+			},
+			wantSubstr: "ERROR: err k=v",
+		},
+		{
+			name: "DebugContext",
+			log: func(l *Logger) {
+				l.DebugContext(context.Background(), "dbg")
+			},
+			wantSubstr: "DEBUG: dbg",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := NewLogger(newBase(&buf))
+			logger.SetLevel(DebugLevel)
+
+			tc.log(logger)
+
+			if !strings.Contains(buf.String(), tc.wantSubstr) {
+				t.Errorf("got %q, want substring %q", buf.String(), tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestLegacyLoggerContextMessageFormatting(t *testing.T) {
+	tests := []struct {
+		name       string
+		msg        string
+		args       []any
+		wantSubstr string
+	}{
+		{
+			name:       "no extra args",
+			msg:        "plain",
+			wantSubstr: "INFO: plain",
+		},
+		{
+			name:       "odd number of args",
+			msg:        "partial",
+			args:       []any{"only", "one", "pair"},
+			wantSubstr: "INFO: partial only one pair",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := NewLogger(newBase(&buf))
+			logger.SetLevel(InfoLevel)
+
+			logger.InfoContext(context.Background(), tc.msg, tc.args...)
+
+			if !strings.Contains(buf.String(), tc.wantSubstr) {
+				t.Errorf("got %q, want substring %q", buf.String(), tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestLegacyLoggerContextRespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(newBase(&buf))
+	logger.SetLevel(WarnLevel)
+
+	logger.InfoContext(context.Background(), "hidden")
+	if buf.Len() != 0 {
+		t.Errorf("InfoContext should be suppressed at WarnLevel, got %q", buf.String())
+	}
+}
+
+func parseJSONLog(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var rec map[string]any
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("invalid json: %v; got %q", err, string(data))
+	}
+	return rec
+}

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -1,0 +1,83 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq/internal/base"
+	asynqcontext "github.com/hibiken/asynq/internal/context"
+)
+
+func TestStructuredLoggerDebugContext(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := NewStructuredLogger(slog.New(h), DebugLevel)
+
+	logger.DebugContext(context.Background(), "hello", "component", "test")
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("invalid json: %v; got %q", err, buf.String())
+	}
+	if rec["msg"] != "hello" {
+		t.Errorf("msg = %v, want hello", rec["msg"])
+	}
+	if rec["component"] != "test" {
+		t.Errorf("component = %v, want test", rec["component"])
+	}
+}
+
+func TestStructuredLoggerRespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := NewStructuredLogger(slog.New(h), InfoLevel)
+
+	logger.DebugContext(context.Background(), "hidden")
+	if buf.Len() != 0 {
+		t.Errorf("DebugContext should be suppressed at InfoLevel, got %q", buf.String())
+	}
+}
+
+func TestStructuredLoggerTaskAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := NewStructuredLogger(slog.New(h), DebugLevel)
+
+	msg := &base.TaskMessage{
+		ID:    "task-123",
+		Queue: "default",
+	}
+	ctx, cancel := asynqcontext.New(context.Background(), msg, time.Now().Add(time.Minute))
+	defer cancel()
+
+	logger.InfoContext(ctx, "processing")
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("invalid json: %v; got %q", err, buf.String())
+	}
+	if rec["task_id"] != "task-123" {
+		t.Errorf("task_id = %v, want task-123", rec["task_id"])
+	}
+	if rec["queue"] != "default" {
+		t.Errorf("queue = %v, want default", rec["queue"])
+	}
+}
+
+func TestLegacyLoggerContextFallback(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(newBase(&buf))
+	logger.SetLevel(DebugLevel)
+
+	logger.InfoContext(context.Background(), "hello", "key", "value")
+
+	got := buf.String()
+	if !strings.Contains(got, "INFO: hello key=value") {
+		t.Errorf("got %q, want message with key=value", got)
+	}
+}

--- a/janitor.go
+++ b/janitor.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -52,7 +53,7 @@ func newJanitor(params janitorParams) *janitor {
 }
 
 func (j *janitor) shutdown() {
-	j.logger.Debug("Janitor shutting down...")
+	j.logger.DebugContext(context.Background(), "Janitor shutting down", "component", "janitor")
 	// Signal the janitor goroutine to stop.
 	j.done <- struct{}{}
 }
@@ -66,7 +67,7 @@ func (j *janitor) start(wg *sync.WaitGroup) {
 		for {
 			select {
 			case <-j.done:
-				j.logger.Debug("Janitor done")
+				j.logger.DebugContext(context.Background(), "Janitor done", "component", "janitor")
 				return
 			case <-timer.C:
 				j.exec()
@@ -79,8 +80,8 @@ func (j *janitor) start(wg *sync.WaitGroup) {
 func (j *janitor) exec() {
 	for _, qname := range j.queues {
 		if err := j.broker.DeleteExpiredCompletedTasks(qname, j.batchSize); err != nil {
-			j.logger.Errorf("Failed to delete expired completed tasks from queue %q: %v",
-				qname, err)
+			j.logger.ErrorContext(context.Background(), "Failed to delete expired completed tasks",
+				"component", "janitor", "queue", qname, "error", err)
 		}
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,47 @@
+package asynq
+
+import (
+	"log/slog"
+
+	"github.com/hibiken/asynq/internal/log"
+)
+
+// WithStructuredLogger returns a function that sets cfg.StructuredLogger.
+//
+// When StructuredLogger is set, asynq uses log/slog context-aware logging
+// for internal logs. Config.Logger is ignored in that case.
+//
+// Example:
+//
+//	cfg := asynq.Config{Concurrency: 10, LogLevel: asynq.InfoLevel}
+//	asynq.WithStructuredLogger(slog.Default())(&cfg)
+//	srv := asynq.NewServer(redisOpt, cfg)
+func WithStructuredLogger(l *slog.Logger) func(*Config) {
+	return func(c *Config) {
+		c.StructuredLogger = l
+	}
+}
+
+// WithStructuredLoggerForScheduler returns a function that sets opts.StructuredLogger.
+//
+// When StructuredLogger is set, asynq uses log/slog context-aware logging
+// for internal logs. SchedulerOpts.Logger is ignored in that case.
+func WithStructuredLoggerForScheduler(l *slog.Logger) func(*SchedulerOpts) {
+	return func(o *SchedulerOpts) {
+		o.StructuredLogger = l
+	}
+}
+
+func newLogger(logger Logger, structuredLogger *slog.Logger, logLevel LogLevel) *log.Logger {
+	loglevel := logLevel
+	if loglevel == level_unspecified {
+		loglevel = InfoLevel
+	}
+	level := toInternalLogLevel(loglevel)
+	if structuredLogger != nil {
+		return log.NewStructuredLogger(structuredLogger, level)
+	}
+	l := log.NewLogger(logger)
+	l.SetLevel(level)
+	return l
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,49 @@
+package asynq
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+func TestWithStructuredLogger(t *testing.T) {
+	var buf bytes.Buffer
+	slogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	cfg := Config{LogLevel: DebugLevel}
+	WithStructuredLogger(slogger)(&cfg)
+
+	if cfg.StructuredLogger != slogger {
+		t.Fatal("StructuredLogger not set on Config")
+	}
+
+	logger := newLogger(cfg.Logger, cfg.StructuredLogger, cfg.LogLevel)
+	logger.InfoContext(context.Background(), "test", "component", "server")
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if rec["msg"] != "test" {
+		t.Errorf("msg = %v, want test", rec["msg"])
+	}
+}
+
+func TestNewLoggerLegacyPath(t *testing.T) {
+	logger := newLogger(nil, nil, InfoLevel)
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+	logger.Info("legacy path ok")
+}
+
+func TestWithStructuredLoggerForScheduler(t *testing.T) {
+	slogger := slog.Default()
+	opts := &SchedulerOpts{}
+	WithStructuredLoggerForScheduler(slogger)(opts)
+	if opts.StructuredLogger != slogger {
+		t.Fatal("StructuredLogger not set on SchedulerOpts")
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -39,11 +39,76 @@ func TestNewLoggerLegacyPath(t *testing.T) {
 	logger.Info("legacy path ok")
 }
 
+func TestNewLoggerLegacyFatalLevel(t *testing.T) {
+	logger := newLogger(nil, nil, FatalLevel)
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+}
+
 func TestWithStructuredLoggerForScheduler(t *testing.T) {
 	slogger := slog.Default()
 	opts := &SchedulerOpts{}
 	WithStructuredLoggerForScheduler(slogger)(opts)
 	if opts.StructuredLogger != slogger {
 		t.Fatal("StructuredLogger not set on SchedulerOpts")
+	}
+}
+
+func TestNewLoggerStructuredWithAllLogLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLevel LogLevel
+		wantMsg  string
+	}{
+		{name: "WarnLevel", logLevel: WarnLevel, wantMsg: "warn level"},
+		{name: "ErrorLevel", logLevel: ErrorLevel, wantMsg: "error level"},
+		{name: "DebugLevel", logLevel: DebugLevel, wantMsg: "debug level"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			slogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			logger := newLogger(nil, slogger, tc.logLevel)
+
+			switch tc.logLevel {
+			case WarnLevel:
+				logger.WarnContext(context.Background(), tc.wantMsg)
+			case ErrorLevel:
+				logger.ErrorContext(context.Background(), tc.wantMsg)
+			case DebugLevel:
+				logger.DebugContext(context.Background(), tc.wantMsg)
+			}
+
+			var rec map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+				t.Fatalf("invalid json: %v; got %q", err, buf.String())
+			}
+			if rec["msg"] != tc.wantMsg {
+				t.Errorf("msg = %v, want %q", rec["msg"], tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestNewLoggerStructuredDefaultsUnspecifiedLevel(t *testing.T) {
+	var buf bytes.Buffer
+	slogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	logger := newLogger(nil, slogger, LogLevel(0)) // level_unspecified
+	logger.DebugContext(context.Background(), "hidden at default info level")
+	if buf.Len() != 0 {
+		t.Errorf("DebugContext should be suppressed when level is unspecified (defaults to Info), got %q", buf.String())
+	}
+
+	logger.InfoContext(context.Background(), "unspecified defaults to info")
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if rec["msg"] != "unspecified defaults to info" {
+		t.Errorf("msg = %v, want unspecified defaults to info", rec["msg"])
 	}
 }

--- a/periodic_task_manager.go
+++ b/periodic_task_manager.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"sort"
@@ -134,7 +135,7 @@ func (mgr *PeriodicTaskManager) Start() error {
 		for {
 			select {
 			case <-mgr.done:
-				mgr.s.logger.Debugf("Stopping syncer goroutine")
+				mgr.s.logger.DebugContext(context.Background(), "Stopping syncer goroutine", "component", "periodic_task_manager")
 				ticker.Stop()
 				return
 			case <-ticker.C:
@@ -161,7 +162,7 @@ func (mgr *PeriodicTaskManager) Run() error {
 	}
 	mgr.s.waitForSignals()
 	mgr.Shutdown()
-	mgr.s.logger.Debugf("PeriodicTaskManager exiting")
+	mgr.s.logger.DebugContext(context.Background(), "PeriodicTaskManager exiting", "component", "periodic_task_manager")
 	return nil
 }
 
@@ -183,36 +184,36 @@ func (mgr *PeriodicTaskManager) add(configs []*PeriodicTaskConfig) {
 	for _, c := range configs {
 		entryID, err := mgr.s.Register(c.Cronspec, c.Task, c.Opts...)
 		if err != nil {
-			mgr.s.logger.Errorf("Failed to register periodic task: cronspec=%q task=%q err=%v",
-				c.Cronspec, c.Task.Type(), err)
+			mgr.s.logger.ErrorContext(context.Background(), "Failed to register periodic task",
+				"component", "periodic_task_manager", "cronspec", c.Cronspec, "task_type", c.Task.Type(), "error", err)
 			continue
 		}
 		mgr.m[c.hash()] = entryID
-		mgr.s.logger.Infof("Successfully registered periodic task: cronspec=%q task=%q, entryID=%s",
-			c.Cronspec, c.Task.Type(), entryID)
+		mgr.s.logger.InfoContext(context.Background(), "Successfully registered periodic task",
+			"component", "periodic_task_manager", "cronspec", c.Cronspec, "task_type", c.Task.Type(), "entry_id", entryID)
 	}
 }
 
 func (mgr *PeriodicTaskManager) remove(removed map[string]string) {
 	for hash, entryID := range removed {
 		if err := mgr.s.Unregister(entryID); err != nil {
-			mgr.s.logger.Errorf("Failed to unregister periodic task: %v", err)
+			mgr.s.logger.ErrorContext(context.Background(), "Failed to unregister periodic task", "component", "periodic_task_manager", "error", err)
 			continue
 		}
 		delete(mgr.m, hash)
-		mgr.s.logger.Infof("Successfully unregistered periodic task: entryID=%s", entryID)
+		mgr.s.logger.InfoContext(context.Background(), "Successfully unregistered periodic task", "component", "periodic_task_manager", "entry_id", entryID)
 	}
 }
 
 func (mgr *PeriodicTaskManager) sync() {
 	configs, err := mgr.p.GetConfigs()
 	if err != nil {
-		mgr.s.logger.Errorf("Failed to get periodic task configs: %v", err)
+		mgr.s.logger.ErrorContext(context.Background(), "Failed to get periodic task configs", "component", "periodic_task_manager", "error", err)
 		return
 	}
 	for _, c := range configs {
 		if err := validatePeriodicTaskConfig(c); err != nil {
-			mgr.s.logger.Errorf("Failed to sync: GetConfigs returned an invalid config: %v", err)
+			mgr.s.logger.ErrorContext(context.Background(), "Failed to sync: GetConfigs returned an invalid config", "component", "periodic_task_manager", "error", err)
 			return
 		}
 	}

--- a/processor.go
+++ b/processor.go
@@ -90,6 +90,13 @@ type processorParams struct {
 	finished          chan<- *base.TaskMessage
 }
 
+func (p *processor) logCtx() context.Context {
+	if p.baseCtxFn != nil {
+		return p.baseCtxFn()
+	}
+	return context.Background()
+}
+
 // newProcessor constructs a new processor.
 func newProcessor(params processorParams) *processor {
 	queues := normalizeQueues(params.queues)
@@ -126,7 +133,7 @@ func newProcessor(params processorParams) *processor {
 // It's safe to call this method multiple times.
 func (p *processor) stop() {
 	p.once.Do(func() {
-		p.logger.Debug("Processor shutting down...")
+		p.logger.DebugContext(p.logCtx(), "Processor shutting down", "component", "processor")
 		// Unblock if processor is waiting for sema token.
 		close(p.quit)
 		// Signal the processor goroutine to stop processing tasks
@@ -141,12 +148,12 @@ func (p *processor) shutdown() {
 
 	time.AfterFunc(p.shutdownTimeout, func() { close(p.abort) })
 
-	p.logger.Info("Waiting for all workers to finish...")
+	p.logger.InfoContext(p.logCtx(), "Waiting for all workers to finish", "component", "processor")
 	// block until all workers have released the token
 	for i := 0; i < cap(p.sema); i++ {
 		p.sema <- struct{}{}
 	}
-	p.logger.Info("All workers have finished")
+	p.logger.InfoContext(p.logCtx(), "All workers have finished", "component", "processor")
 }
 
 func (p *processor) start(wg *sync.WaitGroup) {
@@ -156,7 +163,7 @@ func (p *processor) start(wg *sync.WaitGroup) {
 		for {
 			select {
 			case <-p.done:
-				p.logger.Debug("Processor done")
+				p.logger.DebugContext(p.logCtx(), "Processor done", "component", "processor")
 				return
 			default:
 				p.exec()
@@ -176,7 +183,7 @@ func (p *processor) exec() {
 		msg, leaseExpirationTime, err := p.broker.Dequeue(qnames...)
 		switch {
 		case errors.Is(err, errors.ErrNoProcessableTask):
-			p.logger.Debug("All queues are empty")
+			p.logger.DebugContext(p.logCtx(), "All queues are empty", "component", "processor")
 			// Queues are empty, this is a normal behavior.
 			// Sleep to avoid slamming redis and let scheduler move tasks into queues.
 			// Note: We are not using blocking pop operation and polling queues instead.
@@ -187,7 +194,7 @@ func (p *processor) exec() {
 			return
 		case err != nil:
 			if p.errLogLimiter.Allow() {
-				p.logger.Errorf("Dequeue error: %v", err)
+				p.logger.ErrorContext(p.logCtx(), "Dequeue error", "component", "processor", "error", err)
 			}
 			<-p.sema // release token
 			return
@@ -237,8 +244,8 @@ func (p *processor) exec() {
 			select {
 			case <-p.abort:
 				// time is up, push the message back to queue and quit this worker goroutine.
-				p.logger.Warnf("Quitting worker. task id=%s", msg.ID)
-				p.requeue(lease, msg)
+				p.logger.WarnContext(ctx, "Quitting worker", "component", "processor", "task_id", msg.ID)
+				p.requeue(ctx, lease, msg)
 				return
 			case <-lease.Done():
 				cancel()
@@ -252,13 +259,13 @@ func (p *processor) exec() {
 					p.handleFailedMessage(ctx, lease, msg, resErr)
 					return
 				}
-				p.handleSucceededMessage(lease, msg)
+				p.handleSucceededMessage(ctx, lease, msg)
 			}
 		}()
 	}
 }
 
-func (p *processor) requeue(l *base.Lease, msg *base.TaskMessage) {
+func (p *processor) requeue(ctx context.Context, l *base.Lease, msg *base.TaskMessage) {
 	if !l.IsValid() {
 		// If lease is not valid, do not write to redis; Let recoverer take care of it.
 		return
@@ -267,21 +274,21 @@ func (p *processor) requeue(l *base.Lease, msg *base.TaskMessage) {
 	defer cancel()
 	err := p.broker.Requeue(ctx, msg)
 	if err != nil {
-		p.logger.Errorf("Could not push task id=%s back to queue: %v", msg.ID, err)
+		p.logger.ErrorContext(ctx, "Could not push task back to queue", "component", "processor", "task_id", msg.ID, "error", err)
 	} else {
-		p.logger.Infof("Pushed task id=%s back to queue", msg.ID)
+		p.logger.InfoContext(ctx, "Pushed task back to queue", "component", "processor", "task_id", msg.ID)
 	}
 }
 
-func (p *processor) handleSucceededMessage(l *base.Lease, msg *base.TaskMessage) {
+func (p *processor) handleSucceededMessage(ctx context.Context, l *base.Lease, msg *base.TaskMessage) {
 	if msg.Retention > 0 {
-		p.markAsComplete(l, msg)
+		p.markAsComplete(ctx, l, msg)
 	} else {
-		p.markAsDone(l, msg)
+		p.markAsDone(ctx, l, msg)
 	}
 }
 
-func (p *processor) markAsComplete(l *base.Lease, msg *base.TaskMessage) {
+func (p *processor) markAsComplete(ctx context.Context, l *base.Lease, msg *base.TaskMessage) {
 	if !l.IsValid() {
 		// If lease is not valid, do not write to redis; Let recoverer take care of it.
 		return
@@ -292,7 +299,7 @@ func (p *processor) markAsComplete(l *base.Lease, msg *base.TaskMessage) {
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not move task id=%s type=%q from %q to %q:  %+v",
 			msg.ID, msg.Type, base.ActiveKey(msg.Queue), base.CompletedKey(msg.Queue), err)
-		p.logger.Warnf("%s; Will retry syncing", errMsg)
+		p.logger.WarnContext(ctx, "Will retry syncing", "component", "processor", "error", errMsg)
 		p.syncRequestCh <- &syncRequest{
 			fn: func() error {
 				return p.broker.MarkAsComplete(ctx, msg)
@@ -303,7 +310,7 @@ func (p *processor) markAsComplete(l *base.Lease, msg *base.TaskMessage) {
 	}
 }
 
-func (p *processor) markAsDone(l *base.Lease, msg *base.TaskMessage) {
+func (p *processor) markAsDone(ctx context.Context, l *base.Lease, msg *base.TaskMessage) {
 	if !l.IsValid() {
 		// If lease is not valid, do not write to redis; Let recoverer take care of it.
 		return
@@ -313,7 +320,7 @@ func (p *processor) markAsDone(l *base.Lease, msg *base.TaskMessage) {
 	err := p.broker.Done(ctx, msg)
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not remove task id=%s type=%q from %q err: %+v", msg.ID, msg.Type, base.ActiveKey(msg.Queue), err)
-		p.logger.Warnf("%s; Will retry syncing", errMsg)
+		p.logger.WarnContext(ctx, "Will retry syncing", "component", "processor", "error", errMsg)
 		p.syncRequestCh <- &syncRequest{
 			fn: func() error {
 				return p.broker.Done(ctx, msg)
@@ -338,17 +345,17 @@ func (p *processor) handleFailedMessage(ctx context.Context, l *base.Lease, msg 
 	}
 	switch {
 	case errors.Is(err, RevokeTask):
-		p.logger.Warnf("revoke task id=%s", msg.ID)
-		p.markAsDone(l, msg)
+		p.logger.WarnContext(ctx, "revoke task", "component", "processor", "task_id", msg.ID)
+		p.markAsDone(ctx, l, msg)
 	case msg.Retried >= msg.Retry || errors.Is(err, SkipRetry):
-		p.logger.Warnf("Retry exhausted for task id=%s", msg.ID)
-		p.archive(l, msg, err)
+		p.logger.WarnContext(ctx, "Retry exhausted for task", "component", "processor", "task_id", msg.ID)
+		p.archive(ctx, l, msg, err)
 	default:
-		p.retry(l, msg, err, p.isFailureFunc(err))
+		p.retry(ctx, l, msg, err, p.isFailureFunc(err))
 	}
 }
 
-func (p *processor) retry(l *base.Lease, msg *base.TaskMessage, e error, isFailure bool) {
+func (p *processor) retry(ctx context.Context, l *base.Lease, msg *base.TaskMessage, e error, isFailure bool) {
 	if !l.IsValid() {
 		// If lease is not valid, do not write to redis; Let recoverer take care of it.
 		return
@@ -360,7 +367,7 @@ func (p *processor) retry(l *base.Lease, msg *base.TaskMessage, e error, isFailu
 	err := p.broker.Retry(ctx, msg, retryAt, e.Error(), isFailure)
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not move task id=%s from %q to %q", msg.ID, base.ActiveKey(msg.Queue), base.RetryKey(msg.Queue))
-		p.logger.Warnf("%s; Will retry syncing", errMsg)
+		p.logger.WarnContext(ctx, "Will retry syncing", "component", "processor", "error", errMsg)
 		p.syncRequestCh <- &syncRequest{
 			fn: func() error {
 				return p.broker.Retry(ctx, msg, retryAt, e.Error(), isFailure)
@@ -371,7 +378,7 @@ func (p *processor) retry(l *base.Lease, msg *base.TaskMessage, e error, isFailu
 	}
 }
 
-func (p *processor) archive(l *base.Lease, msg *base.TaskMessage, e error) {
+func (p *processor) archive(ctx context.Context, l *base.Lease, msg *base.TaskMessage, e error) {
 	if !l.IsValid() {
 		// If lease is not valid, do not write to redis; Let recoverer take care of it.
 		return
@@ -381,7 +388,7 @@ func (p *processor) archive(l *base.Lease, msg *base.TaskMessage, e error) {
 	err := p.broker.Archive(ctx, msg, e.Error())
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not move task id=%s from %q to %q", msg.ID, base.ActiveKey(msg.Queue), base.ArchivedKey(msg.Queue))
-		p.logger.Warnf("%s; Will retry syncing", errMsg)
+		p.logger.WarnContext(ctx, "Will retry syncing", "component", "processor", "error", errMsg)
 		p.syncRequestCh <- &syncRequest{
 			fn: func() error {
 				return p.broker.Archive(ctx, msg, e.Error())
@@ -424,7 +431,7 @@ func (p *processor) queues() []string {
 func (p *processor) perform(ctx context.Context, task *Task) (err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			p.logger.Errorf("recovering from panic. See the stack trace below for details:\n%s", string(debug.Stack()))
+			p.logger.ErrorContext(ctx, "recovering from panic", "component", "processor", "stack", string(debug.Stack()))
 			_, file, line, ok := runtime.Caller(1) // skip the first frame (panic itself)
 			if ok && strings.Contains(file, "runtime/") {
 				// The panic came from the runtime, most likely due to incorrect
@@ -523,7 +530,7 @@ func gcd(xs ...int) int {
 // computeDeadline returns the given task's deadline,
 func (p *processor) computeDeadline(msg *base.TaskMessage) time.Time {
 	if msg.Timeout == 0 && msg.Deadline == 0 {
-		p.logger.Errorf("asynq: internal error: both timeout and deadline are not set for the task message: %s", msg.ID)
+		p.logger.ErrorContext(p.logCtx(), "asynq: internal error: both timeout and deadline are not set for the task message", "component", "processor", "task_id", msg.ID)
 		return p.clock.Now().Add(defaultTimeout)
 	}
 	if msg.Timeout != 0 && msg.Deadline != 0 {

--- a/recoverer.go
+++ b/recoverer.go
@@ -52,7 +52,7 @@ func newRecoverer(params recovererParams) *recoverer {
 }
 
 func (r *recoverer) shutdown() {
-	r.logger.Debug("Recoverer shutting down...")
+	r.logger.DebugContext(context.Background(), "Recoverer shutting down", "component", "recoverer")
 	// Signal the recoverer goroutine to stop polling.
 	r.done <- struct{}{}
 }
@@ -66,7 +66,7 @@ func (r *recoverer) start(wg *sync.WaitGroup) {
 		for {
 			select {
 			case <-r.done:
-				r.logger.Debug("Recoverer done")
+				r.logger.DebugContext(context.Background(), "Recoverer done", "component", "recoverer")
 				timer.Stop()
 				return
 			case <-timer.C:
@@ -91,7 +91,7 @@ func (r *recoverer) recoverLeaseExpiredTasks() {
 	cutoff := time.Now().Add(-30 * time.Second)
 	msgs, err := r.broker.ListLeaseExpired(cutoff, r.queues...)
 	if err != nil {
-		r.logger.Warnf("recoverer: could not list lease expired tasks: %v", err)
+		r.logger.WarnContext(context.Background(), "recoverer: could not list lease expired tasks", "component", "recoverer", "error", err)
 		return
 	}
 	for _, msg := range msgs {
@@ -106,7 +106,7 @@ func (r *recoverer) recoverLeaseExpiredTasks() {
 func (r *recoverer) recoverStaleAggregationSets() {
 	for _, qname := range r.queues {
 		if err := r.broker.ReclaimStaleAggregationSets(qname); err != nil {
-			r.logger.Warnf("recoverer: could not reclaim stale aggregation sets in queue %q: %v", qname, err)
+			r.logger.WarnContext(context.Background(), "recoverer: could not reclaim stale aggregation sets", "component", "recoverer", "queue", qname, "error", err)
 		}
 	}
 }
@@ -115,12 +115,12 @@ func (r *recoverer) retry(msg *base.TaskMessage, err error) {
 	delay := r.retryDelayFunc(msg.Retried, err, NewTaskWithHeaders(msg.Type, msg.Payload, msg.Headers))
 	retryAt := time.Now().Add(delay)
 	if err := r.broker.Retry(context.Background(), msg, retryAt, err.Error(), r.isFailureFunc(err)); err != nil {
-		r.logger.Warnf("recoverer: could not retry lease expired task: %v", err)
+		r.logger.WarnContext(context.Background(), "recoverer: could not retry lease expired task", "component", "recoverer", "error", err)
 	}
 }
 
 func (r *recoverer) archive(msg *base.TaskMessage, err error) {
 	if err := r.broker.Archive(context.Background(), msg, err.Error()); err != nil {
-		r.logger.Warnf("recoverer: could not move task to archive: %v", err)
+		r.logger.WarnContext(context.Background(), "recoverer: could not move task to archive", "component", "recoverer", "error", err)
 	}
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -5,7 +5,9 @@
 package asynq
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"sync"
 	"time"
@@ -88,12 +90,7 @@ func newScheduler(opts *SchedulerOpts) *Scheduler {
 		heartbeatInterval = defaultHeartbeatInterval
 	}
 
-	logger := log.NewLogger(opts.Logger)
-	loglevel := opts.LogLevel
-	if loglevel == level_unspecified {
-		loglevel = InfoLevel
-	}
-	logger.SetLevel(toInternalLogLevel(loglevel))
+	logger := newLogger(opts.Logger, opts.StructuredLogger, opts.LogLevel)
 
 	loc := opts.Location
 	if loc == nil {
@@ -137,7 +134,13 @@ type SchedulerOpts struct {
 	// Logger specifies the logger used by the scheduler instance.
 	//
 	// If unset, the default logger is used.
+	// Ignored when StructuredLogger is set.
 	Logger Logger
+
+	// StructuredLogger specifies a log/slog logger for context-aware structured logging.
+	//
+	// If set, asynq uses slog's context methods for internal logs and ignores Logger.
+	StructuredLogger *slog.Logger
 
 	// LogLevel specifies the minimum log level to enable.
 	//
@@ -192,14 +195,14 @@ func (j *enqueueJob) Run() {
 		}
 		return
 	}
-	j.logger.Debugf("scheduler enqueued a task: %+v", info)
+	j.logger.DebugContext(context.Background(), "scheduler enqueued a task", "component", "scheduler", "task", info)
 	event := &base.SchedulerEnqueueEvent{
 		TaskID:     info.ID,
 		EnqueuedAt: time.Now().In(j.location),
 	}
 	err = j.rdb.RecordSchedulerEnqueueEvent(j.id.String(), event)
 	if err != nil {
-		j.logger.Warnf("scheduler could not record enqueue event of enqueued task %s: %v", info.ID, err)
+		j.logger.WarnContext(context.Background(), "scheduler could not record enqueue event of enqueued task", "component", "scheduler", "task_id", info.ID, "error", err)
 	}
 }
 
@@ -260,8 +263,8 @@ func (s *Scheduler) Start() error {
 	if err := s.start(); err != nil {
 		return err
 	}
-	s.logger.Info("Scheduler starting")
-	s.logger.Infof("Scheduler timezone is set to %v", s.location)
+	s.logger.InfoContext(context.Background(), "Scheduler starting", "component", "scheduler")
+	s.logger.InfoContext(context.Background(), "Scheduler timezone is set", "component", "scheduler", "timezone", s.location)
 	s.cron.Start()
 	s.wg.Add(1)
 	go s.runHeartbeater()
@@ -294,7 +297,7 @@ func (s *Scheduler) Shutdown() {
 	s.state.value = srvStateClosed
 	s.state.mu.Unlock()
 
-	s.logger.Info("Scheduler shutting down")
+	s.logger.InfoContext(context.Background(), "Scheduler shutting down", "component", "scheduler")
 	close(s.done) // signal heartbeater to stop
 	ctx := s.cron.Stop()
 	<-ctx.Done()
@@ -302,9 +305,9 @@ func (s *Scheduler) Shutdown() {
 
 	s.clearHistory()
 	if err := s.client.Close(); err != nil {
-		s.logger.Errorf("Failed to close redis client connection: %v", err)
+		s.logger.ErrorContext(context.Background(), "Failed to close redis client connection", "component", "scheduler", "error", err)
 	}
-	s.logger.Info("Scheduler stopped")
+	s.logger.InfoContext(context.Background(), "Scheduler stopped", "component", "scheduler")
 }
 
 func (s *Scheduler) runHeartbeater() {
@@ -313,9 +316,9 @@ func (s *Scheduler) runHeartbeater() {
 	for {
 		select {
 		case <-s.done:
-			s.logger.Debugf("Scheduler heatbeater shutting down")
+			s.logger.DebugContext(context.Background(), "Scheduler heatbeater shutting down", "component", "scheduler")
 			if err := s.rdb.ClearSchedulerEntries(s.id); err != nil {
-				s.logger.Errorf("Failed to clear the scheduler entries: %v", err)
+				s.logger.ErrorContext(context.Background(), "Failed to clear the scheduler entries", "component", "scheduler", "error", err)
 			}
 			ticker.Stop()
 			return
@@ -342,7 +345,7 @@ func (s *Scheduler) beat() {
 		entries = append(entries, e)
 	}
 	if err := s.rdb.WriteSchedulerEntries(s.id, entries, s.heartbeatInterval*2); err != nil {
-		s.logger.Warnf("Scheduler could not write heartbeat data: %v", err)
+		s.logger.WarnContext(context.Background(), "Scheduler could not write heartbeat data", "component", "scheduler", "error", err)
 	}
 }
 
@@ -358,7 +361,7 @@ func (s *Scheduler) clearHistory() {
 	for _, entry := range s.cron.Entries() {
 		job := entry.Job.(*enqueueJob)
 		if err := s.rdb.ClearSchedulerHistory(job.id.String()); err != nil {
-			s.logger.Warnf("Could not clear scheduler history for entry %q: %v", job.id.String(), err)
+			s.logger.WarnContext(context.Background(), "Could not clear scheduler history for entry", "component", "scheduler", "entry_id", job.id.String(), "error", err)
 		}
 	}
 }

--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"math/rand/v2"
 	"runtime"
@@ -66,7 +67,7 @@ type serverStateValue int
 const (
 	// StateNew represents a new server. Server begins in
 	// this state and then transition to StatusActive when
-	// Start or Run is callled.
+	// Start or Run is called.
 	srvStateNew serverStateValue = iota
 
 	// StateActive indicates the server is up and active.
@@ -188,7 +189,13 @@ type Config struct {
 	// Logger specifies the logger used by the server instance.
 	//
 	// If unset, default logger is used.
+	// Ignored when StructuredLogger is set.
 	Logger Logger
+
+	// StructuredLogger specifies a log/slog logger for context-aware structured logging.
+	//
+	// If set, asynq uses slog's context methods for internal logs and ignores Logger.
+	StructuredLogger *slog.Logger
 
 	// LogLevel specifies the minimum log level to enable.
 	//
@@ -496,12 +503,7 @@ func NewServerFromRedisClient(c redis.UniversalClient, cfg Config) *Server {
 	if groupGracePeriod < time.Second {
 		panic("GroupGracePeriod cannot be less than a second")
 	}
-	logger := log.NewLogger(cfg.Logger)
-	loglevel := cfg.LogLevel
-	if loglevel == level_unspecified {
-		loglevel = InfoLevel
-	}
-	logger.SetLevel(toInternalLogLevel(loglevel))
+	logger := newLogger(cfg.Logger, cfg.StructuredLogger, cfg.LogLevel)
 
 	rdb := rdb.NewRDB(c)
 	starting := make(chan *workerInfo)
@@ -583,8 +585,8 @@ func NewServerFromRedisClient(c redis.UniversalClient, cfg Config) *Server {
 		janitorBatchSize = defaultJanitorBatchSize
 	}
 	if janitorBatchSize > defaultJanitorBatchSize {
-		logger.Warnf("Janitor batch size of %d is greater than the recommended batch size of %d. "+
-			"This might cause a long-running script", janitorBatchSize, defaultJanitorBatchSize)
+		logger.WarnContext(context.Background(), "Janitor batch size is greater than the recommended batch size; this might cause a long-running script",
+			"component", "server", "batch_size", janitorBatchSize, "recommended_batch_size", defaultJanitorBatchSize)
 	}
 	janitor := newJanitor(janitorParams{
 		logger:    logger,
@@ -686,7 +688,7 @@ func (srv *Server) Start(handler Handler) error {
 	if err := srv.start(); err != nil {
 		return err
 	}
-	srv.logger.Info("Starting processing")
+	srv.logger.InfoContext(context.Background(), "Starting processing", "component", "server")
 
 	srv.heartbeater.start(&srv.wg)
 	srv.healthchecker.start(&srv.wg)
@@ -731,7 +733,7 @@ func (srv *Server) Shutdown() {
 	srv.state.value = srvStateClosed
 	srv.state.mu.Unlock()
 
-	srv.logger.Info("Starting graceful shutdown")
+	srv.logger.InfoContext(context.Background(), "Starting graceful shutdown", "component", "server")
 	// Note: The order of shutdown is important.
 	// Sender goroutines should be terminated before the receiver goroutines.
 	// processor -> syncer (via syncCh)
@@ -750,7 +752,7 @@ func (srv *Server) Shutdown() {
 	if !srv.sharedConnection {
 		srv.broker.Close()
 	}
-	srv.logger.Info("Exiting")
+	srv.logger.InfoContext(context.Background(), "Exiting", "component", "server")
 }
 
 // Stop signals the server to stop pulling new tasks off queues.
@@ -768,9 +770,9 @@ func (srv *Server) Stop() {
 	srv.state.value = srvStateStopped
 	srv.state.mu.Unlock()
 
-	srv.logger.Info("Stopping processor")
+	srv.logger.InfoContext(context.Background(), "Stopping processor", "component", "server")
 	srv.processor.stop()
-	srv.logger.Info("Processor stopped")
+	srv.logger.InfoContext(context.Background(), "Processor stopped", "component", "server")
 }
 
 // Ping performs a ping against the redis connection.

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -3,6 +3,7 @@
 package asynq
 
 import (
+	"context"
 	"os"
 	"os/signal"
 
@@ -14,8 +15,8 @@ import (
 // SIGTERM and SIGINT will signal the process to exit.
 // SIGTSTP will signal the process to stop processing new tasks.
 func (srv *Server) waitForSignals() {
-	srv.logger.Info("Send signal TSTP to stop processing new tasks")
-	srv.logger.Info("Send signal TERM or INT to terminate the process")
+	srv.logger.InfoContext(context.Background(), "Send signal TSTP to stop processing new tasks", "component", "server")
+	srv.logger.InfoContext(context.Background(), "Send signal TERM or INT to terminate the process", "component", "server")
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, unix.SIGTERM, unix.SIGINT, unix.SIGTSTP)
@@ -32,7 +33,7 @@ func (srv *Server) waitForSignals() {
 }
 
 func (s *Scheduler) waitForSignals() {
-	s.logger.Info("Send signal TERM or INT to stop the scheduler")
+	s.logger.InfoContext(context.Background(), "Send signal TERM or INT to stop the scheduler", "component", "scheduler")
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, unix.SIGTERM, unix.SIGINT)
 	<-sigs

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -3,6 +3,7 @@
 package asynq
 
 import (
+	"context"
 	"os"
 	"os/signal"
 
@@ -15,14 +16,14 @@ import (
 //
 // Note: Currently SIGTSTP is not supported for windows build.
 func (srv *Server) waitForSignals() {
-	srv.logger.Info("Send signal TERM or INT to terminate the process")
+	srv.logger.InfoContext(context.Background(), "Send signal TERM or INT to terminate the process", "component", "server")
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, windows.SIGTERM, windows.SIGINT)
 	<-sigs
 }
 
 func (s *Scheduler) waitForSignals() {
-	s.logger.Info("Send signal TERM or INT to stop the scheduler")
+	s.logger.InfoContext(context.Background(), "Send signal TERM or INT to stop the scheduler", "component", "scheduler")
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, windows.SIGTERM, windows.SIGINT)
 	<-sigs

--- a/subscriber.go
+++ b/subscriber.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -44,7 +45,7 @@ func newSubscriber(params subscriberParams) *subscriber {
 }
 
 func (s *subscriber) shutdown() {
-	s.logger.Debug("Subscriber shutting down...")
+	s.logger.DebugContext(context.Background(), "Subscriber shutting down", "component", "subscriber")
 	// Signal the subscriber goroutine to stop.
 	s.done <- struct{}{}
 }
@@ -61,12 +62,12 @@ func (s *subscriber) start(wg *sync.WaitGroup) {
 		for {
 			pubsub, err = s.broker.CancelationPubSub()
 			if err != nil {
-				s.logger.Errorf("cannot subscribe to cancelation channel: %v", err)
+				s.logger.ErrorContext(context.Background(), "cannot subscribe to cancelation channel", "component", "subscriber", "error", err)
 				select {
 				case <-time.After(s.retryTimeout):
 					continue
 				case <-s.done:
-					s.logger.Debug("Subscriber done")
+					s.logger.DebugContext(context.Background(), "Subscriber done", "component", "subscriber")
 					return
 				}
 			}
@@ -77,7 +78,7 @@ func (s *subscriber) start(wg *sync.WaitGroup) {
 			select {
 			case <-s.done:
 				pubsub.Close()
-				s.logger.Debug("Subscriber done")
+				s.logger.DebugContext(context.Background(), "Subscriber done", "component", "subscriber")
 				return
 			case msg := <-cancelCh:
 				cancel, ok := s.cancelations.Get(msg.Payload)

--- a/syncer.go
+++ b/syncer.go
@@ -5,6 +5,7 @@
 package asynq
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -47,7 +48,7 @@ func newSyncer(params syncerParams) *syncer {
 }
 
 func (s *syncer) shutdown() {
-	s.logger.Debug("Syncer shutting down...")
+	s.logger.DebugContext(context.Background(), "Syncer shutting down", "component", "syncer")
 	// Signal the syncer goroutine to stop.
 	s.done <- struct{}{}
 }
@@ -63,10 +64,10 @@ func (s *syncer) start(wg *sync.WaitGroup) {
 				// Try sync one last time before shutting down.
 				for _, req := range requests {
 					if err := req.fn(); err != nil {
-						s.logger.Error(req.errMsg)
+						s.logger.ErrorContext(context.Background(), req.errMsg, "component", "syncer")
 					}
 				}
-				s.logger.Debug("Syncer done")
+				s.logger.DebugContext(context.Background(), "Syncer done", "component", "syncer")
 				return
 			case req := <-s.requestsCh:
 				requests = append(requests, req)


### PR DESCRIPTION
Abused work's cursor account to to the heavy lifting updating everything

* Add logging wrapper to make existing logger speak slog
* Update log statements to include context and have fields separated

As far as I can tell, this shouldn't break any existing logging other than modifying the format slightly, by dropping the field=value type thing
Also cursor added component everywhere, which i figured wasn't a bad idea.

still would need some work so proper context gets used/passed through everywhere to fully support https://github.com/hibiken/asynq/issues/1016 but its a start.