### PR TITLE
Add pluggable backend foundation

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,0 +1,77 @@
+// Copyright 2020 Kentaro Hibino. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package asynq
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hibiken/asynq/internal/base"
+)
+
+// ErrFeatureNotSupported indicates that a backend does not support the requested feature.
+var ErrFeatureNotSupported = errors.New("asynq: feature is not supported by backend")
+
+// ErrNoProcessableTask indicates that a backend has no task ready for processing.
+var ErrNoProcessableTask = errors.New("asynq: no processable task")
+
+// TaskMessage is the storage-facing representation used by pluggable backends.
+type TaskMessage struct {
+	ID           string
+	Type         string
+	Payload      []byte
+	Headers      map[string]string
+	Queue        string
+	Retry        int
+	Retried      int
+	ErrorMsg     string
+	LastFailedAt time.Time
+	Timeout      time.Duration
+	Deadline     time.Time
+	UniqueKey    string
+	GroupKey     string
+	Retention    time.Duration
+	CompletedAt  time.Time
+	RunAt        time.Time
+}
+
+// Backend defines the minimum contract required to enqueue and process tasks
+// without depending on Redis-specific internals.
+type Backend interface {
+	Ping(ctx context.Context) error
+	Close() error
+	Enqueue(ctx context.Context, msg *TaskMessage) error
+	Dequeue(ctx context.Context, queues []string) (*TaskMessage, error)
+	Done(ctx context.Context, msg *TaskMessage) error
+	Retry(ctx context.Context, msg *TaskMessage, processAt time.Time, errMsg string) error
+	Archive(ctx context.Context, msg *TaskMessage, errMsg string) error
+}
+
+// TaskMessageFromInternal converts Asynq's Redis-oriented task message into
+// the public storage-facing message used by pluggable backends.
+func TaskMessageFromInternal(msg *base.TaskMessage, runAt time.Time) *TaskMessage {
+	if msg == nil {
+		return nil
+	}
+	return &TaskMessage{
+		ID:           msg.ID,
+		Type:         msg.Type,
+		Payload:      msg.Payload,
+		Headers:      msg.Headers,
+		Queue:        msg.Queue,
+		Retry:        msg.Retry,
+		Retried:      msg.Retried,
+		ErrorMsg:     msg.ErrorMsg,
+		LastFailedAt: fromUnixTimeOrZero(msg.LastFailedAt),
+		Timeout:      time.Duration(msg.Timeout) * time.Second,
+		Deadline:     fromUnixTimeOrZero(msg.Deadline),
+		UniqueKey:    msg.UniqueKey,
+		GroupKey:     msg.GroupKey,
+		Retention:    time.Duration(msg.Retention) * time.Second,
+		CompletedAt:  fromUnixTimeOrZero(msg.CompletedAt),
+		RunAt:        runAt,
+	}
+}

--- a/backend_runner.go
+++ b/backend_runner.go
@@ -1,0 +1,228 @@
+// Copyright 2020 Kentaro Hibino. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package asynq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"runtime"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/hibiken/asynq/internal/log"
+)
+
+type backendRunner struct {
+	logger  *log.Logger
+	backend Backend
+	state   *serverState
+
+	baseCtxFn         func() context.Context
+	retryDelayFunc    RetryDelayFunc
+	isFailureFunc     func(error) bool
+	errHandler        ErrorHandler
+	taskCheckInterval time.Duration
+	shutdownTimeout   time.Duration
+	queues            []string
+
+	sema  chan struct{}
+	done  chan struct{}
+	abort chan struct{}
+	once  sync.Once
+	wg    sync.WaitGroup
+}
+
+func newBackendRunner(logger *log.Logger, backend Backend, cfg Config, state *serverState) *backendRunner {
+	baseCtxFn := cfg.BaseContext
+	if baseCtxFn == nil {
+		baseCtxFn = context.Background
+	}
+	n := cfg.Concurrency
+	if n < 1 {
+		n = runtime.NumCPU()
+	}
+	taskCheckInterval := cfg.TaskCheckInterval
+	if taskCheckInterval <= 0 {
+		taskCheckInterval = defaultTaskCheckInterval
+	}
+	retryDelayFunc := cfg.RetryDelayFunc
+	if retryDelayFunc == nil {
+		retryDelayFunc = DefaultRetryDelayFunc
+	}
+	isFailureFunc := cfg.IsFailure
+	if isFailureFunc == nil {
+		isFailureFunc = defaultIsFailureFunc
+	}
+	shutdownTimeout := cfg.ShutdownTimeout
+	if shutdownTimeout == 0 {
+		shutdownTimeout = defaultShutdownTimeout
+	}
+	queues := normalizeServerQueues(cfg.Queues)
+	qnames := make([]string, 0, len(queues))
+	for q := range queues {
+		qnames = append(qnames, q)
+	}
+	return &backendRunner{
+		logger:            logger,
+		backend:           backend,
+		state:             state,
+		baseCtxFn:         baseCtxFn,
+		retryDelayFunc:    retryDelayFunc,
+		isFailureFunc:     isFailureFunc,
+		errHandler:        cfg.ErrorHandler,
+		taskCheckInterval: taskCheckInterval,
+		shutdownTimeout:   shutdownTimeout,
+		queues:            qnames,
+		sema:              make(chan struct{}, n),
+		done:              make(chan struct{}),
+		abort:             make(chan struct{}),
+	}
+}
+
+func (r *backendRunner) start(handler Handler) {
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		for {
+			select {
+			case <-r.done:
+				return
+			default:
+				r.exec(handler)
+			}
+		}
+	}()
+}
+
+func (r *backendRunner) shutdown() {
+	r.once.Do(func() {
+		close(r.done)
+		time.AfterFunc(r.shutdownTimeout, func() { close(r.abort) })
+	})
+	for i := 0; i < cap(r.sema); i++ {
+		r.sema <- struct{}{}
+	}
+	r.wg.Wait()
+}
+
+func (r *backendRunner) exec(handler Handler) {
+	select {
+	case <-r.done:
+		return
+	case r.sema <- struct{}{}:
+		msg, err := r.backend.Dequeue(r.baseCtxFn(), r.queues)
+		switch {
+		case errors.Is(err, ErrNoProcessableTask):
+			jitter := rand.N(r.taskCheckInterval)
+			time.Sleep(r.taskCheckInterval/2 + jitter)
+			<-r.sema
+			return
+		case err != nil:
+			r.logger.Errorf("Backend dequeue error: %v", err)
+			<-r.sema
+			return
+		}
+
+		r.wg.Add(1)
+		go func() {
+			defer func() {
+				<-r.sema
+				r.wg.Done()
+			}()
+			r.process(handler, msg)
+		}()
+	}
+}
+
+func (r *backendRunner) process(handler Handler, msg *TaskMessage) {
+	ctx, cancel := r.taskContext(msg)
+	defer cancel()
+	task := newTask(msg.Type, msg.Payload, nil)
+	task.headers = msg.Headers
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.perform(handler, ctx, task)
+	}()
+	select {
+	case <-r.abort:
+		r.retry(ctx, msg, context.Canceled)
+	case <-ctx.Done():
+		r.retry(ctx, msg, ctx.Err())
+	case err := <-errCh:
+		if err != nil {
+			r.handleFailed(ctx, msg, task, err)
+			return
+		}
+		msg.CompletedAt = time.Now()
+		if err := r.backend.Done(ctx, msg); err != nil {
+			r.logger.Errorf("Could not mark backend task id=%s as done: %v", msg.ID, err)
+		}
+	}
+}
+
+func (r *backendRunner) taskContext(msg *TaskMessage) (context.Context, context.CancelFunc) {
+	ctx := r.baseCtxFn()
+	if !msg.Deadline.IsZero() && msg.Timeout > 0 {
+		timeoutDeadline := time.Now().Add(msg.Timeout)
+		if msg.Deadline.Before(timeoutDeadline) {
+			return context.WithDeadline(ctx, msg.Deadline)
+		}
+		return context.WithDeadline(ctx, timeoutDeadline)
+	}
+	if !msg.Deadline.IsZero() {
+		return context.WithDeadline(ctx, msg.Deadline)
+	}
+	if msg.Timeout > 0 {
+		return context.WithTimeout(ctx, msg.Timeout)
+	}
+	return context.WithTimeout(ctx, defaultTimeout)
+}
+
+func (r *backendRunner) handleFailed(ctx context.Context, msg *TaskMessage, task *Task, err error) {
+	if r.errHandler != nil {
+		r.errHandler.HandleError(ctx, task, err)
+	}
+	switch {
+	case errors.Is(err, RevokeTask):
+		if err := r.backend.Done(ctx, msg); err != nil {
+			r.logger.Errorf("Could not revoke backend task id=%s: %v", msg.ID, err)
+		}
+	case msg.Retried >= msg.Retry || errors.Is(err, SkipRetry):
+		r.archive(ctx, msg, err)
+	default:
+		r.retry(ctx, msg, err)
+	}
+}
+
+func (r *backendRunner) retry(ctx context.Context, msg *TaskMessage, err error) {
+	msg.Retried++
+	msg.ErrorMsg = err.Error()
+	msg.LastFailedAt = time.Now()
+	retryAt := time.Now().Add(r.retryDelayFunc(msg.Retried, err, NewTaskWithHeaders(msg.Type, msg.Payload, msg.Headers)))
+	if e := r.backend.Retry(ctx, msg, retryAt, err.Error()); e != nil {
+		r.logger.Errorf("Could not retry backend task id=%s: %v", msg.ID, e)
+	}
+}
+
+func (r *backendRunner) archive(ctx context.Context, msg *TaskMessage, err error) {
+	msg.ErrorMsg = err.Error()
+	msg.LastFailedAt = time.Now()
+	if e := r.backend.Archive(ctx, msg, err.Error()); e != nil {
+		r.logger.Errorf("Could not archive backend task id=%s: %v", msg.ID, e)
+	}
+}
+
+func (r *backendRunner) perform(handler Handler, ctx context.Context, task *Task) (err error) {
+	defer func() {
+		if x := recover(); x != nil {
+			r.logger.Errorf("recovering from panic. See the stack trace below for details:\n%s", string(debug.Stack()))
+			err = fmt.Errorf("panic: %v", x)
+		}
+	}()
+	return handler.ProcessTask(ctx, task)
+}

--- a/client.go
+++ b/client.go
@@ -26,10 +26,16 @@ import (
 //
 // Clients are safe for concurrent use by multiple goroutines.
 type Client struct {
-	broker base.Broker
+	broker  base.Broker
+	backend Backend
 	// When a Client has been created with an existing Redis connection, we do
 	// not want to close it.
 	sharedConnection bool
+}
+
+// NewClientWithBackend returns a new Client instance backed by a pluggable backend.
+func NewClientWithBackend(b Backend) *Client {
+	return &Client{backend: b}
 }
 
 // NewClient returns a new Client instance given a redis connection option.
@@ -46,7 +52,8 @@ func NewClient(r RedisConnOpt) *Client {
 // NewClientFromRedisClient returns a new instance of Client given a redis.UniversalClient
 // Warning: The underlying redis connection pool will not be closed by Asynq, you are responsible for closing it.
 func NewClientFromRedisClient(c redis.UniversalClient) *Client {
-	return &Client{broker: rdb.NewRDB(c), sharedConnection: true}
+	b := rdb.NewRDB(c)
+	return &Client{broker: b, backend: nil, sharedConnection: true}
 }
 
 type OptionType int
@@ -348,6 +355,9 @@ var (
 
 // Close closes the connection with redis.
 func (c *Client) Close() error {
+	if c.backend != nil {
+		return c.backend.Close()
+	}
 	if c.sharedConnection {
 		return fmt.Errorf("redis connection is shared so the Client can't be closed through asynq")
 	}
@@ -496,6 +506,14 @@ type BatchEnqueueResult struct {
 // Immediate and scheduled (via [ProcessAt] or [ProcessIn]) tasks are supported.
 // Group and unique tasks are rejected as described above.
 func (c *Client) BatchEnqueueContext(ctx context.Context, tasks []*Task, opts ...Option) []BatchEnqueueResult {
+	if c.backend != nil {
+		results := make([]BatchEnqueueResult, len(tasks))
+		for i, task := range tasks {
+			info, err := c.EnqueueContext(ctx, task, opts...)
+			results[i] = BatchEnqueueResult{TaskInfo: info, Err: err}
+		}
+		return results
+	}
 	results := make([]BatchEnqueueResult, len(tasks))
 	if len(tasks) == 0 {
 		return results
@@ -594,10 +612,16 @@ func (c *Client) BatchEnqueueContext(ctx context.Context, tasks []*Task, opts ..
 
 // Ping performs a ping against the redis connection.
 func (c *Client) Ping() error {
+	if c.backend != nil {
+		return c.backend.Ping(context.Background())
+	}
 	return c.broker.Ping()
 }
 
 func (c *Client) enqueue(ctx context.Context, msg *base.TaskMessage, uniqueTTL time.Duration) error {
+	if c.backend != nil {
+		return c.backend.Enqueue(ctx, TaskMessageFromInternal(msg, time.Now()))
+	}
 	if uniqueTTL > 0 {
 		return c.broker.EnqueueUnique(ctx, msg, uniqueTTL)
 	}
@@ -605,6 +629,11 @@ func (c *Client) enqueue(ctx context.Context, msg *base.TaskMessage, uniqueTTL t
 }
 
 func (c *Client) schedule(ctx context.Context, msg *base.TaskMessage, t time.Time, uniqueTTL time.Duration) error {
+	if c.backend != nil {
+		publicMsg := TaskMessageFromInternal(msg, t)
+		publicMsg.RunAt = t
+		return c.backend.Enqueue(ctx, publicMsg)
+	}
 	if uniqueTTL > 0 {
 		ttl := time.Until(t.Add(uniqueTTL))
 		return c.broker.ScheduleUnique(ctx, msg, t, ttl)
@@ -613,6 +642,9 @@ func (c *Client) schedule(ctx context.Context, msg *base.TaskMessage, t time.Tim
 }
 
 func (c *Client) addToGroup(ctx context.Context, msg *base.TaskMessage, group string, uniqueTTL time.Duration) error {
+	if c.backend != nil {
+		return ErrFeatureNotSupported
+	}
 	if uniqueTTL > 0 {
 		return c.broker.AddToGroupUnique(ctx, msg, group, uniqueTTL)
 	}

--- a/server.go
+++ b/server.go
@@ -36,7 +36,8 @@ import (
 type Server struct {
 	logger *log.Logger
 
-	broker base.Broker
+	broker  base.Broker
+	backend Backend
 	// When a Server has been created with an existing Redis connection, we do
 	// not want to close it.
 	sharedConnection bool
@@ -54,6 +55,7 @@ type Server struct {
 	healthchecker *healthchecker
 	janitor       *janitor
 	aggregator    *aggregator
+	runner        *backendRunner
 }
 
 type serverState struct {
@@ -410,6 +412,22 @@ var defaultQueueConfig = map[string]int{
 	base.DefaultQueueName: 1,
 }
 
+func normalizeServerQueues(queues map[string]int) map[string]int {
+	res := make(map[string]int)
+	for qname, p := range queues {
+		if err := base.ValidateQueueName(qname); err != nil {
+			continue
+		}
+		if p > 0 {
+			res[qname] = p
+		}
+	}
+	if len(res) == 0 {
+		res = defaultQueueConfig
+	}
+	return res
+}
+
 const (
 	defaultTaskCheckInterval = 1 * time.Second
 
@@ -438,6 +456,27 @@ func NewServer(r RedisConnOpt, cfg Config) *Server {
 	return server
 }
 
+// NewServerWithBackend returns a new Server instance backed by a pluggable backend.
+func NewServerWithBackend(b Backend, cfg Config) *Server {
+	logger := log.NewLogger(cfg.Logger)
+	loglevel := cfg.LogLevel
+	if loglevel == level_unspecified {
+		loglevel = InfoLevel
+	}
+	logger.SetLevel(toInternalLogLevel(loglevel))
+	if len(cfg.Queues) == 0 {
+		cfg.Queues = map[string]int{"default": 1}
+	}
+	cfg.Queues = normalizeServerQueues(cfg.Queues)
+	srvState := &serverState{value: srvStateNew}
+	return &Server{
+		logger:  logger,
+		backend: b,
+		state:   srvState,
+		runner:  newBackendRunner(logger, b, cfg, srvState),
+	}
+}
+
 // NewServerFromRedisClient returns a new instance of Server given a redis.UniversalClient
 // and server configuration
 // Warning: The underlying redis connection pool will not be closed by Asynq, you are responsible for closing it.
@@ -464,18 +503,7 @@ func NewServerFromRedisClient(c redis.UniversalClient, cfg Config) *Server {
 	if isFailureFunc == nil {
 		isFailureFunc = defaultIsFailureFunc
 	}
-	queues := make(map[string]int)
-	for qname, p := range cfg.Queues {
-		if err := base.ValidateQueueName(qname); err != nil {
-			continue // ignore invalid queue names
-		}
-		if p > 0 {
-			queues[qname] = p
-		}
-	}
-	if len(queues) == 0 {
-		queues = defaultQueueConfig
-	}
+	queues := normalizeServerQueues(cfg.Queues)
 	var qnames []string
 	for q := range queues {
 		qnames = append(qnames, q)
@@ -605,6 +633,7 @@ func NewServerFromRedisClient(c redis.UniversalClient, cfg Config) *Server {
 	return &Server{
 		logger:           logger,
 		broker:           rdb,
+		backend:          nil,
 		sharedConnection: true,
 		state:            srvState,
 		forwarder:        forwarder,
@@ -681,6 +710,13 @@ func (srv *Server) Start(handler Handler) error {
 	if handler == nil {
 		return fmt.Errorf("asynq: server cannot run with nil handler")
 	}
+	if srv.backend != nil {
+		if err := srv.start(); err != nil {
+			return err
+		}
+		srv.runner.start(handler)
+		return nil
+	}
 	srv.processor.handler = handler
 
 	if err := srv.start(); err != nil {
@@ -736,18 +772,24 @@ func (srv *Server) Shutdown() {
 	// Sender goroutines should be terminated before the receiver goroutines.
 	// processor -> syncer (via syncCh)
 	// processor -> heartbeater (via starting, finished channels)
-	srv.forwarder.shutdown()
-	srv.processor.shutdown()
-	srv.recoverer.shutdown()
-	srv.syncer.shutdown()
-	srv.subscriber.shutdown()
-	srv.janitor.shutdown()
-	srv.aggregator.shutdown()
-	srv.healthchecker.shutdown()
-	srv.heartbeater.shutdown()
-	srv.wg.Wait()
+	if srv.backend != nil {
+		srv.runner.shutdown()
+	} else {
+		srv.forwarder.shutdown()
+		srv.processor.shutdown()
+		srv.recoverer.shutdown()
+		srv.syncer.shutdown()
+		srv.subscriber.shutdown()
+		srv.janitor.shutdown()
+		srv.aggregator.shutdown()
+		srv.healthchecker.shutdown()
+		srv.heartbeater.shutdown()
+		srv.wg.Wait()
+	}
 
-	if !srv.sharedConnection {
+	if srv.backend != nil {
+		_ = srv.backend.Close()
+	} else if !srv.sharedConnection {
 		srv.broker.Close()
 	}
 	srv.logger.Info("Exiting")
@@ -768,6 +810,13 @@ func (srv *Server) Stop() {
 	srv.state.value = srvStateStopped
 	srv.state.mu.Unlock()
 
+	if srv.backend != nil {
+		srv.logger.Info("Stopping backend workers")
+		srv.runner.shutdown()
+		srv.logger.Info("Backend workers stopped")
+		return
+	}
+
 	srv.logger.Info("Stopping processor")
 	srv.processor.stop()
 	srv.logger.Info("Processor stopped")
@@ -782,6 +831,8 @@ func (srv *Server) Ping() error {
 	if srv.state.value == srvStateClosed {
 		return nil
 	}
-
+	if srv.backend != nil {
+		return srv.backend.Ping(context.Background())
+	}
 	return srv.broker.Ping()
 }


### PR DESCRIPTION
### What does this PR do?

Adds a small pluggable backend foundation so Asynq clients and servers can be backed by a storage implementation that is not tied directly to Redis internals.

This introduces:

- A public `Backend` interface for enqueue/dequeue/task lifecycle operations.
- A public `TaskMessage` storage-facing representation.
- `NewClientWithBackend` for backend-backed enqueue flows.
- `NewServerWithBackend` and an internal backend runner for backend-backed processing.
- Redis behavior preserved as the existing default path.

### Motivation

Asynq currently exposes Redis connection options as the only first-class backend path. This PR creates the minimum public surface needed to experiment with alternate storage backends while keeping the existing Redis APIs and behavior unchanged.

No linked issue currently exists for this foundation PR.

### Design notes

- The existing Redis-backed `NewClient`, `NewServer`, and `NewServerFromRedisClient` paths remain unchanged by default.
- Backend-backed clients route enqueue/schedule operations through `Backend.Enqueue`.
- Backend-backed servers use a separate internal runner instead of changing the Redis processor pipeline.
- Backend implementations can return `ErrFeatureNotSupported` for behavior that is not part of the minimum contract, such as grouped/unique Redis-specific behavior.
- The `TaskMessage` type intentionally mirrors the storage-facing fields needed by the backend contract rather than exposing internal Redis message types directly.

### Compatibility

This is intended to be additive. Existing Redis users should continue to use the same constructors and code paths as before.

### Tests

I do not have a completed CI run attached to this PR yet. The change is structured so the Redis default path remains the existing behavior, and the new backend path is isolated behind the new constructors.

### Review focus

The main thing I would like feedback on is the shape of the initial `Backend` interface and whether this is the right minimum foundation before adding concrete backend implementations.
