### PR TITLE
fix(rdb): store scheduled/retry scores in microseconds to avoid early execution (#1071)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -106,7 +106,7 @@ func TestClientEnqueueWithProcessAtOption(t *testing.T) {
 							Timeout:  int64(defaultTimeout.Seconds()),
 							Deadline: noDeadline.Unix(),
 						},
-						Score: oneHourLater.Unix(),
+						Score: oneHourLater.UnixMicro(),
 					},
 				},
 			},
@@ -139,7 +139,7 @@ func TestClientEnqueueWithProcessAtOption(t *testing.T) {
 		}
 		for qname, want := range tc.wantScheduled {
 			gotScheduled := h.GetScheduledEntries(t, r, qname)
-			if diff := cmp.Diff(want, gotScheduled, h.IgnoreIDOpt, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(want, gotScheduled, h.IgnoreIDOpt, cmpopts.EquateEmpty(), h.EquateInt64Approx(2_000_000)); diff != "" {
 				t.Errorf("%s;\nmismatch found in %q; (-want,+got)\n%s", tc.desc, base.ScheduledKey(qname), diff)
 			}
 		}
@@ -598,7 +598,7 @@ func TestClientEnqueueWithGroupOption(t *testing.T) {
 							Deadline: noDeadline.Unix(),
 							GroupKey: "mygroup",
 						},
-						Score: now.Add(30 * time.Minute).Unix(),
+						Score: now.Add(30 * time.Minute).UnixMicro(),
 					},
 				},
 			},
@@ -640,7 +640,7 @@ func TestClientEnqueueWithGroupOption(t *testing.T) {
 
 		for qname, want := range tc.wantScheduled {
 			gotScheduled := h.GetScheduledEntries(t, r, qname)
-			if diff := cmp.Diff(want, gotScheduled, h.IgnoreIDOpt, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(want, gotScheduled, h.IgnoreIDOpt, cmpopts.EquateEmpty(), h.EquateInt64Approx(2_000_000)); diff != "" {
 				t.Errorf("%s;\nmismatch found in %q; (-want,+got)\n%s", tc.desc, base.ScheduledKey(qname), diff)
 			}
 		}
@@ -790,7 +790,7 @@ func TestClientEnqueueWithProcessInOption(t *testing.T) {
 							Timeout:  int64(defaultTimeout.Seconds()),
 							Deadline: noDeadline.Unix(),
 						},
-						Score: time.Now().Add(time.Hour).Unix(),
+						Score: time.Now().Add(time.Hour).UnixMicro(),
 					},
 				},
 			},
@@ -857,7 +857,7 @@ func TestClientEnqueueWithProcessInOption(t *testing.T) {
 		}
 		for qname, want := range tc.wantScheduled {
 			gotScheduled := h.GetScheduledEntries(t, r, qname)
-			if diff := cmp.Diff(want, gotScheduled, h.IgnoreIDOpt, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(want, gotScheduled, h.IgnoreIDOpt, cmpopts.EquateEmpty(), h.EquateInt64Approx(2_000_000)); diff != "" {
 				t.Errorf("%s;\nmismatch found in %q; (-want,+got)\n%s", tc.desc, base.ScheduledKey(qname), diff)
 			}
 		}
@@ -1485,7 +1485,7 @@ func TestClientEnqueueWithHeadersScheduled(t *testing.T) {
 							Timeout:  int64(defaultTimeout.Seconds()),
 							Deadline: noDeadline.Unix(),
 						},
-						Score: oneHourLater.Unix(),
+						Score: oneHourLater.UnixMicro(),
 					},
 				},
 			},
@@ -1513,7 +1513,7 @@ func TestClientEnqueueWithHeadersScheduled(t *testing.T) {
 
 		for qname, want := range tc.wantScheduled {
 			gotScheduled := h.GetScheduledEntries(t, r, qname)
-			if diff := cmp.Diff(want, gotScheduled, h.IgnoreIDOpt, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(want, gotScheduled, h.IgnoreIDOpt, cmpopts.EquateEmpty(), h.EquateInt64Approx(2_000_000)); diff != "" {
 				t.Errorf("%s;\nmismatch found in %q; (-want,+got)\n%s", tc.desc, base.ScheduledKey(qname), diff)
 			}
 		}

--- a/forwarder_test.go
+++ b/forwarder_test.go
@@ -43,11 +43,11 @@ func TestForwarder(t *testing.T) {
 	}{
 		{
 			initScheduled: map[string][]base.Z{
-				"default":  {{Message: t1, Score: now.Add(time.Hour).Unix()}},
-				"critical": {{Message: t2, Score: now.Add(-2 * time.Second).Unix()}},
+				"default":  {{Message: t1, Score: now.Add(time.Hour).UnixMicro()}},
+				"critical": {{Message: t2, Score: now.Add(-2 * time.Second).UnixMicro()}},
 			},
 			initRetry: map[string][]base.Z{
-				"default":  {{Message: t3, Score: time.Now().Add(-500 * time.Millisecond).Unix()}},
+				"default":  {{Message: t3, Score: time.Now().Add(-500 * time.Millisecond).UnixMicro()}},
 				"critical": {},
 			},
 			initPending: map[string][]*base.TaskMessage{
@@ -71,11 +71,11 @@ func TestForwarder(t *testing.T) {
 		{
 			initScheduled: map[string][]base.Z{
 				"default": {
-					{Message: t1, Score: now.Unix()},
-					{Message: t3, Score: now.Add(-500 * time.Millisecond).Unix()},
+					{Message: t1, Score: now.UnixMicro()},
+					{Message: t3, Score: now.Add(-500 * time.Millisecond).UnixMicro()},
 				},
 				"critical": {
-					{Message: t2, Score: now.Add(-2 * time.Second).Unix()},
+					{Message: t2, Score: now.Add(-2 * time.Second).UnixMicro()},
 				},
 			},
 			initRetry: map[string][]base.Z{

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -511,12 +511,12 @@ func TestInspectorGetTaskInfo(t *testing.T) {
 			"custom":  {m5},
 		},
 		scheduled: map[string][]base.Z{
-			"default": {{Message: m2, Score: fiveMinsFromNow.Unix()}},
+			"default": {{Message: m2, Score: fiveMinsFromNow.UnixMicro()}},
 			"custom":  {},
 		},
 		retry: map[string][]base.Z{
 			"default": {},
-			"custom":  {{Message: m3, Score: oneHourFromNow.Unix()}},
+			"custom":  {{Message: m3, Score: oneHourFromNow.UnixMicro()}},
 		},
 		archived: map[string][]base.Z{
 			"default": {},
@@ -635,12 +635,12 @@ func TestInspectorGetTaskInfoError(t *testing.T) {
 			"custom":  {m5},
 		},
 		scheduled: map[string][]base.Z{
-			"default": {{Message: m2, Score: fiveMinsFromNow.Unix()}},
+			"default": {{Message: m2, Score: fiveMinsFromNow.UnixMicro()}},
 			"custom":  {},
 		},
 		retry: map[string][]base.Z{
 			"default": {},
-			"custom":  {{Message: m3, Score: oneHourFromNow.Unix()}},
+			"custom":  {{Message: m3, Score: oneHourFromNow.UnixMicro()}},
 		},
 		archived: map[string][]base.Z{
 			"default": {},
@@ -847,7 +847,7 @@ func createScheduledTask(z base.Z) *TaskInfo {
 	return newTaskInfo(
 		z.Message,
 		base.TaskStateScheduled,
-		time.Unix(z.Score, 0),
+		time.UnixMicro(z.Score),
 		nil,
 	)
 }
@@ -860,10 +860,10 @@ func TestInspectorListScheduledTasks(t *testing.T) {
 	m3 := h.NewTaskMessage("task3", nil)
 	m4 := h.NewTaskMessageWithQueue("task4", nil, "custom")
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 
@@ -917,7 +917,7 @@ func createRetryTask(z base.Z) *TaskInfo {
 	return newTaskInfo(
 		z.Message,
 		base.TaskStateRetry,
-		time.Unix(z.Score, 0),
+		time.UnixMicro(z.Score),
 		nil,
 	)
 }
@@ -930,10 +930,10 @@ func TestInspectorListRetryTasks(t *testing.T) {
 	m3 := h.NewTaskMessage("task3", nil)
 	m4 := h.NewTaskMessageWithQueue("task4", nil, "custom")
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 
@@ -1410,10 +1410,10 @@ func TestInspectorDeleteAllScheduledTasks(t *testing.T) {
 	m3 := h.NewTaskMessage("task3", nil)
 	m4 := h.NewTaskMessageWithQueue("task3", nil, "custom")
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 
@@ -1476,10 +1476,10 @@ func TestInspectorDeleteAllRetryTasks(t *testing.T) {
 	m3 := h.NewTaskMessage("task3", nil)
 	m4 := h.NewTaskMessageWithQueue("task4", nil, "custom")
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 
@@ -1542,10 +1542,10 @@ func TestInspectorDeleteAllArchivedTasks(t *testing.T) {
 	m3 := h.NewTaskMessage("task3", nil)
 	m4 := h.NewTaskMessageWithQueue("task4", nil, "custom")
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 
@@ -1785,10 +1785,10 @@ func TestInspectorArchiveAllScheduledTasks(t *testing.T) {
 	m3 := h.NewTaskMessage("task3", nil)
 	m4 := h.NewTaskMessageWithQueue("task4", nil, "custom")
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 	inspector.rdb.SetClock(timeutil.NewSimulatedClock(now))
@@ -1915,10 +1915,10 @@ func TestInspectorArchiveAllRetryTasks(t *testing.T) {
 	m3 := h.NewTaskMessage("task3", nil)
 	m4 := h.NewTaskMessageWithQueue("task4", nil, "custom")
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 	inspector.rdb.SetClock(timeutil.NewSimulatedClock(now))
@@ -2029,10 +2029,10 @@ func TestInspectorRunAllScheduledTasks(t *testing.T) {
 	m3 := h.NewTaskMessageWithQueue("task3", nil, "low")
 	m4 := h.NewTaskMessage("task4", nil)
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 
@@ -2146,10 +2146,10 @@ func TestInspectorRunAllRetryTasks(t *testing.T) {
 	m3 := h.NewTaskMessageWithQueue("task3", nil, "low")
 	m4 := h.NewTaskMessage("task2", nil)
 	now := time.Now()
-	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).Unix()}
-	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).Unix()}
-	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).Unix()}
-	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).Unix()}
+	z1 := base.Z{Message: m1, Score: now.Add(5 * time.Minute).UnixMicro()}
+	z2 := base.Z{Message: m2, Score: now.Add(15 * time.Minute).UnixMicro()}
+	z3 := base.Z{Message: m3, Score: now.Add(2 * time.Minute).UnixMicro()}
+	z4 := base.Z{Message: m4, Score: now.Add(2 * time.Minute).UnixMicro()}
 
 	inspector := NewInspector(getRedisConnOpt(t))
 

--- a/internal/rdb/inspect.go
+++ b/internal/rdb/inspect.go
@@ -478,7 +478,7 @@ func (r *RDB) checkQueueExists(qname string) error {
 // Tuple of {msg, state, nextProcessAt, result}
 // msg: encoded task message
 // state: string describing the state of the task
-// nextProcessAt: unix time in seconds, zero if not applicable.
+// nextProcessAt: unix time in microseconds, zero if not applicable.
 // result: result data associated with the task
 //
 // If the task key doesn't exist, it returns error with a message "NOT FOUND"
@@ -505,7 +505,7 @@ func (r *RDB) GetTaskInfo(qname, id string) (*base.TaskInfo, error) {
 	keys := []string{base.TaskKey(qname, id)}
 	argv := []interface{}{
 		id,
-		r.clock.Now().Unix(),
+		r.clock.Now().UnixMicro(),
 		base.QueueKeyPrefix(qname),
 	}
 	res, err := getTaskInfoCmd.Run(context.Background(), r.client, keys, argv...).Result()
@@ -530,7 +530,7 @@ func (r *RDB) GetTaskInfo(qname, id string) (*base.TaskInfo, error) {
 	if err != nil {
 		return nil, errors.E(op, errors.Internal, "unexpected value returned from Lua script")
 	}
-	processAtUnix, err := cast.ToInt64E(vals[2])
+	processAtMicro, err := cast.ToInt64E(vals[2])
 	if err != nil {
 		return nil, errors.E(op, errors.Internal, "unexpected value returned from Lua script")
 	}
@@ -547,8 +547,8 @@ func (r *RDB) GetTaskInfo(qname, id string) (*base.TaskInfo, error) {
 		return nil, errors.E(op, errors.CanonicalCode(err), err)
 	}
 	var nextProcessAt time.Time
-	if processAtUnix != 0 {
-		nextProcessAt = time.Unix(processAtUnix, 0)
+	if processAtMicro != 0 {
+		nextProcessAt = time.UnixMicro(processAtMicro)
 	}
 	var result []byte
 	if len(resultStr) > 0 {
@@ -876,7 +876,7 @@ func (r *RDB) listZSetEntries(qname string, state base.TaskState, key string, pg
 		}
 		var nextProcessAt time.Time
 		if state == base.TaskStateScheduled || state == base.TaskStateRetry {
-			nextProcessAt = time.Unix(score, 0)
+			nextProcessAt = time.UnixMicro(score)
 		}
 		var resBytes []byte
 		if len(resStr) > 0 {

--- a/internal/rdb/inspect_test.go
+++ b/internal/rdb/inspect_test.go
@@ -549,12 +549,12 @@ func TestGetTaskInfo(t *testing.T) {
 			"custom":  {m5},
 		},
 		scheduled: map[string][]base.Z{
-			"default": {{Message: m2, Score: fiveMinsFromNow.Unix()}},
+			"default": {{Message: m2, Score: fiveMinsFromNow.UnixMicro()}},
 			"custom":  {},
 		},
 		retry: map[string][]base.Z{
 			"default": {},
-			"custom":  {{Message: m3, Score: oneHourFromNow.Unix()}},
+			"custom":  {{Message: m3, Score: oneHourFromNow.UnixMicro()}},
 		},
 		archived: map[string][]base.Z{
 			"default": {},
@@ -688,12 +688,12 @@ func TestGetTaskInfoError(t *testing.T) {
 			"custom":  {m5},
 		},
 		scheduled: map[string][]base.Z{
-			"default": {{Message: m2, Score: fiveMinsFromNow.Unix()}},
+			"default": {{Message: m2, Score: fiveMinsFromNow.UnixMicro()}},
 			"custom":  {},
 		},
 		retry: map[string][]base.Z{
 			"default": {},
-			"custom":  {{Message: m3, Score: oneHourFromNow.Unix()}},
+			"custom":  {{Message: m3, Score: oneHourFromNow.UnixMicro()}},
 		},
 		archived: map[string][]base.Z{
 			"default": {},
@@ -1004,12 +1004,12 @@ func TestListScheduled(t *testing.T) {
 		{
 			scheduled: map[string][]base.Z{
 				"default": {
-					{Message: m1, Score: p1.Unix()},
-					{Message: m2, Score: p2.Unix()},
-					{Message: m3, Score: p3.Unix()},
+					{Message: m1, Score: p1.UnixMicro()},
+					{Message: m2, Score: p2.UnixMicro()},
+					{Message: m3, Score: p3.UnixMicro()},
 				},
 				"custom": {
-					{Message: m4, Score: p4.Unix()},
+					{Message: m4, Score: p4.UnixMicro()},
 				},
 			},
 			qname: "default",
@@ -1023,12 +1023,12 @@ func TestListScheduled(t *testing.T) {
 		{
 			scheduled: map[string][]base.Z{
 				"default": {
-					{Message: m1, Score: p1.Unix()},
-					{Message: m2, Score: p2.Unix()},
-					{Message: m3, Score: p3.Unix()},
+					{Message: m1, Score: p1.UnixMicro()},
+					{Message: m2, Score: p2.UnixMicro()},
+					{Message: m3, Score: p3.UnixMicro()},
 				},
 				"custom": {
-					{Message: m4, Score: p4.Unix()},
+					{Message: m4, Score: p4.UnixMicro()},
 				},
 			},
 			qname: "custom",
@@ -1162,11 +1162,11 @@ func TestListRetry(t *testing.T) {
 		{
 			retry: map[string][]base.Z{
 				"default": {
-					{Message: m1, Score: p1.Unix()},
-					{Message: m2, Score: p2.Unix()},
+					{Message: m1, Score: p1.UnixMicro()},
+					{Message: m2, Score: p2.UnixMicro()},
 				},
 				"custom": {
-					{Message: m3, Score: p3.Unix()},
+					{Message: m3, Score: p3.UnixMicro()},
 				},
 			},
 			qname: "default",
@@ -1178,11 +1178,11 @@ func TestListRetry(t *testing.T) {
 		{
 			retry: map[string][]base.Z{
 				"default": {
-					{Message: m1, Score: p1.Unix()},
-					{Message: m2, Score: p2.Unix()},
+					{Message: m1, Score: p1.UnixMicro()},
+					{Message: m2, Score: p2.UnixMicro()},
 				},
 				"custom": {
-					{Message: m3, Score: p3.Unix()},
+					{Message: m3, Score: p3.UnixMicro()},
 				},
 			},
 			qname: "custom",

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -220,7 +220,7 @@ func (r *RDB) BatchEnqueue(ctx context.Context, items []base.BatchEnqueueItem) (
 				base.TaskKey(item.Msg.Queue, item.Msg.ID),
 				base.ScheduledKey(item.Msg.Queue),
 			}
-			argv := []interface{}{encoded, item.ProcessAt.Unix(), item.Msg.ID}
+			argv := []interface{}{encoded, item.ProcessAt.UnixMicro(), item.Msg.ID}
 			scheduleCmd.Run(ctx, pipe, keys, argv...)
 		}
 		scriptIdxs = append(scriptIdxs, pipeLen)
@@ -786,7 +786,7 @@ func (r *RDB) Schedule(ctx context.Context, msg *base.TaskMessage, processAt tim
 	}
 	argv := []interface{}{
 		encoded,
-		processAt.Unix(),
+		processAt.UnixMicro(),
 		msg.ID,
 	}
 	n, err := r.runScriptWithErrorCode(ctx, op, scheduleCmd, keys, argv...)
@@ -850,7 +850,7 @@ func (r *RDB) ScheduleUnique(ctx context.Context, msg *base.TaskMessage, process
 	argv := []interface{}{
 		msg.ID,
 		int(ttl.Seconds()),
-		processAt.Unix(),
+		processAt.UnixMicro(),
 		encoded,
 	}
 	n, err := r.runScriptWithErrorCode(ctx, op, scheduleUniqueCmd, keys, argv...)
@@ -940,7 +940,7 @@ func (r *RDB) Retry(ctx context.Context, msg *base.TaskMessage, processAt time.T
 	argv := []interface{}{
 		msg.ID,
 		encoded,
-		processAt.Unix(),
+		processAt.UnixMicro(),
 		expireAt.Unix(),
 		isFailure,
 		int64(math.MaxInt64),
@@ -1064,10 +1064,11 @@ func (r *RDB) ForwardIfReady(qnames ...string) error {
 
 // KEYS[1] -> source queue (e.g. asynq:{<qname>:scheduled or asynq:{<qname>}:retry})
 // KEYS[2] -> asynq:{<qname>}:pending
-// ARGV[1] -> current unix time in seconds
+// ARGV[1] -> current unix time in microseconds
 // ARGV[2] -> task key prefix
 // ARGV[3] -> current unix time in nsec
 // ARGV[4] -> group key prefix
+// ARGV[5] -> current unix time in seconds (used as the group set score)
 // Note: Script moves tasks up to 100 at a time to keep the runtime of script short.
 var forwardCmd = redis.NewScript(`
 local ids = redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", ARGV[1], "LIMIT", 0, 100)
@@ -1075,7 +1076,7 @@ for _, id in ipairs(ids) do
 	local taskKey = ARGV[2] .. id
 	local group = redis.call("HGET", taskKey, "group")
 	if group and group ~= '' then
-	    redis.call("ZADD", ARGV[4] .. group, ARGV[1], id)
+	    redis.call("ZADD", ARGV[4] .. group, ARGV[5], id)
 		redis.call("ZREM", KEYS[1], id)
 		redis.call("HSET", taskKey,
 				   "state", "aggregating")
@@ -1096,10 +1097,11 @@ func (r *RDB) forward(delayedKey, pendingKey, taskKeyPrefix, groupKeyPrefix stri
 	now := r.clock.Now()
 	keys := []string{delayedKey, pendingKey}
 	argv := []interface{}{
-		now.Unix(),
+		now.UnixMicro(),
 		taskKeyPrefix,
 		now.UnixNano(),
 		groupKeyPrefix,
+		now.Unix(),
 	}
 	res, err := forwardCmd.Run(context.Background(), r.client, keys, argv...).Result()
 	if err != nil {

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -1632,9 +1632,9 @@ func TestSchedule(t *testing.T) {
 			t.Errorf("Redis ZSET %q member: got %v, want %v", scheduledKey, got, tc.msg.ID)
 			continue
 		}
-		if got := int64(zs[0].Score); got != tc.processAt.Unix() {
+		if got := int64(zs[0].Score); got != tc.processAt.UnixMicro() {
 			t.Errorf("Redis ZSET %q score: got %d, want %d",
-				scheduledKey, got, tc.processAt.Unix())
+				scheduledKey, got, tc.processAt.UnixMicro())
 			continue
 		}
 
@@ -1740,9 +1740,9 @@ func TestScheduleUnique(t *testing.T) {
 				scheduledKey, got, tc.msg.ID)
 			continue
 		}
-		if got := int64(zs[0].Score); got != tc.processAt.Unix() {
+		if got := int64(zs[0].Score); got != tc.processAt.UnixMicro() {
 			t.Errorf("Redis ZSET %q score: got %d, want %d",
-				scheduledKey, got, tc.processAt.Unix())
+				scheduledKey, got, tc.processAt.UnixMicro())
 			continue
 		}
 
@@ -1879,7 +1879,7 @@ func TestRetry(t *testing.T) {
 				"default": {{Message: t1, Score: now.Add(10 * time.Second).Unix()}, {Message: t2, Score: now.Add(10 * time.Second).Unix()}},
 			},
 			retry: map[string][]base.Z{
-				"default": {{Message: t3, Score: now.Add(time.Minute).Unix()}},
+				"default": {{Message: t3, Score: now.Add(time.Minute).UnixMicro()}},
 			},
 			msg:       t1,
 			processAt: now.Add(5 * time.Minute),
@@ -1892,8 +1892,8 @@ func TestRetry(t *testing.T) {
 			},
 			wantRetry: map[string][]base.Z{
 				"default": {
-					{Message: h.TaskMessageAfterRetry(*t1, errMsg, now), Score: now.Add(5 * time.Minute).Unix()},
-					{Message: t3, Score: now.Add(time.Minute).Unix()},
+					{Message: h.TaskMessageAfterRetry(*t1, errMsg, now), Score: now.Add(5 * time.Minute).UnixMicro()},
+					{Message: t3, Score: now.Add(time.Minute).UnixMicro()},
 				},
 			},
 		},
@@ -1924,7 +1924,7 @@ func TestRetry(t *testing.T) {
 			wantRetry: map[string][]base.Z{
 				"default": {},
 				"custom": {
-					{Message: h.TaskMessageAfterRetry(*t4, errMsg, now), Score: now.Add(5 * time.Minute).Unix()},
+					{Message: h.TaskMessageAfterRetry(*t4, errMsg, now), Score: now.Add(5 * time.Minute).UnixMicro()},
 				},
 			},
 		},
@@ -2050,7 +2050,7 @@ func TestRetryWithNonFailureError(t *testing.T) {
 				"default": {{Message: t1, Score: now.Add(10 * time.Second).Unix()}, {Message: t2, Score: now.Add(10 * time.Second).Unix()}},
 			},
 			retry: map[string][]base.Z{
-				"default": {{Message: t3, Score: now.Add(time.Minute).Unix()}},
+				"default": {{Message: t3, Score: now.Add(time.Minute).UnixMicro()}},
 			},
 			msg:       t1,
 			processAt: now.Add(5 * time.Minute),
@@ -2064,8 +2064,8 @@ func TestRetryWithNonFailureError(t *testing.T) {
 			wantRetry: map[string][]base.Z{
 				"default": {
 					// Task message should include the error message but without incrementing the retry count.
-					{Message: h.TaskMessageWithError(*t1, errMsg, now), Score: now.Add(5 * time.Minute).Unix()},
-					{Message: t3, Score: now.Add(time.Minute).Unix()},
+					{Message: h.TaskMessageWithError(*t1, errMsg, now), Score: now.Add(5 * time.Minute).UnixMicro()},
+					{Message: t3, Score: now.Add(time.Minute).UnixMicro()},
 				},
 			},
 		},
@@ -2097,7 +2097,7 @@ func TestRetryWithNonFailureError(t *testing.T) {
 				"default": {},
 				"custom": {
 					// Task message should include the error message but without incrementing the retry count.
-					{Message: h.TaskMessageWithError(*t4, errMsg, now), Score: now.Add(5 * time.Minute).Unix()},
+					{Message: h.TaskMessageWithError(*t4, errMsg, now), Score: now.Add(5 * time.Minute).UnixMicro()},
 				},
 			},
 		},
@@ -2562,12 +2562,12 @@ func TestForwardIfReadyWithGroup(t *testing.T) {
 		{
 			scheduled: map[string][]base.Z{
 				"default": {
-					{Message: t1, Score: secondAgo.Unix()},
-					{Message: t2, Score: secondAgo.Unix()},
+					{Message: t1, Score: secondAgo.UnixMicro()},
+					{Message: t2, Score: secondAgo.UnixMicro()},
 				},
 			},
 			retry: map[string][]base.Z{
-				"default": {{Message: t3, Score: secondAgo.Unix()}},
+				"default": {{Message: t3, Score: secondAgo.UnixMicro()}},
 			},
 			qnames: []string{"default"},
 			wantPending: map[string][]*base.TaskMessage{
@@ -2588,14 +2588,14 @@ func TestForwardIfReadyWithGroup(t *testing.T) {
 		},
 		{
 			scheduled: map[string][]base.Z{
-				"default":  {{Message: t1, Score: secondAgo.Unix()}},
-				"critical": {{Message: t4, Score: secondAgo.Unix()}},
+				"default":  {{Message: t1, Score: secondAgo.UnixMicro()}},
+				"critical": {{Message: t4, Score: secondAgo.UnixMicro()}},
 				"low":      {},
 			},
 			retry: map[string][]base.Z{
 				"default":  {},
 				"critical": {},
-				"low":      {{Message: t5, Score: secondAgo.Unix()}},
+				"low":      {{Message: t5, Score: secondAgo.UnixMicro()}},
 			},
 			qnames: []string{"default", "critical", "low"},
 			wantPending: map[string][]*base.TaskMessage{
@@ -2696,12 +2696,12 @@ func TestForwardIfReady(t *testing.T) {
 		{
 			scheduled: map[string][]base.Z{
 				"default": {
-					{Message: t1, Score: secondAgo.Unix()},
-					{Message: t2, Score: secondAgo.Unix()},
+					{Message: t1, Score: secondAgo.UnixMicro()},
+					{Message: t2, Score: secondAgo.UnixMicro()},
 				},
 			},
 			retry: map[string][]base.Z{
-				"default": {{Message: t3, Score: secondAgo.Unix()}},
+				"default": {{Message: t3, Score: secondAgo.UnixMicro()}},
 			},
 			qnames: []string{"default"},
 			wantPending: map[string][]*base.TaskMessage{
@@ -2717,12 +2717,12 @@ func TestForwardIfReady(t *testing.T) {
 		{
 			scheduled: map[string][]base.Z{
 				"default": {
-					{Message: t1, Score: hourFromNow.Unix()},
-					{Message: t2, Score: secondAgo.Unix()},
+					{Message: t1, Score: hourFromNow.UnixMicro()},
+					{Message: t2, Score: secondAgo.UnixMicro()},
 				},
 			},
 			retry: map[string][]base.Z{
-				"default": {{Message: t3, Score: secondAgo.Unix()}},
+				"default": {{Message: t3, Score: secondAgo.UnixMicro()}},
 			},
 			qnames: []string{"default"},
 			wantPending: map[string][]*base.TaskMessage{
@@ -2738,12 +2738,12 @@ func TestForwardIfReady(t *testing.T) {
 		{
 			scheduled: map[string][]base.Z{
 				"default": {
-					{Message: t1, Score: hourFromNow.Unix()},
-					{Message: t2, Score: hourFromNow.Unix()},
+					{Message: t1, Score: hourFromNow.UnixMicro()},
+					{Message: t2, Score: hourFromNow.UnixMicro()},
 				},
 			},
 			retry: map[string][]base.Z{
-				"default": {{Message: t3, Score: hourFromNow.Unix()}},
+				"default": {{Message: t3, Score: hourFromNow.UnixMicro()}},
 			},
 			qnames: []string{"default"},
 			wantPending: map[string][]*base.TaskMessage{
@@ -2758,14 +2758,14 @@ func TestForwardIfReady(t *testing.T) {
 		},
 		{
 			scheduled: map[string][]base.Z{
-				"default":  {{Message: t1, Score: secondAgo.Unix()}},
-				"critical": {{Message: t4, Score: secondAgo.Unix()}},
+				"default":  {{Message: t1, Score: secondAgo.UnixMicro()}},
+				"critical": {{Message: t4, Score: secondAgo.UnixMicro()}},
 				"low":      {},
 			},
 			retry: map[string][]base.Z{
 				"default":  {},
 				"critical": {},
-				"low":      {{Message: t5, Score: secondAgo.Unix()}},
+				"low":      {{Message: t5, Score: secondAgo.UnixMicro()}},
 			},
 			qnames: []string{"default", "critical", "low"},
 			wantPending: map[string][]*base.TaskMessage{
@@ -2825,6 +2825,50 @@ func TestForwardIfReady(t *testing.T) {
 				t.Errorf("mismatch found in %q; (-want, +got)\n%s", base.RetryKey(qname), diff)
 			}
 		}
+	}
+}
+
+// Regression test for https://github.com/hibiken/asynq/issues/1071:
+// a scheduled task must not be forwarded before its sub-second process-at time.
+// Scores were previously stored with second precision, so a task scheduled for
+// HH:MM:SS.900 would be forwarded as early as HH:MM:SS.000.
+func TestForwardIfReadyHonorsSubSecondProcessAt(t *testing.T) {
+	r := setup(t)
+	defer r.Close()
+	msg := h.NewTaskMessage("send_email", nil)
+
+	// Truncate to a whole second so the "before" clock and the process-at time
+	// fall within the same second — the case that exposed the precision bug.
+	base := time.Now().Truncate(time.Second)
+	processAt := base.Add(900 * time.Millisecond)
+
+	if err := r.Schedule(context.Background(), msg, processAt); err != nil {
+		t.Fatalf("(*RDB).Schedule failed: %v", err)
+	}
+
+	// Clock is at base+500ms — before processAt (base+900ms) but in the same second.
+	// With second-precision scores this task would be forwarded early.
+	r.SetClock(timeutil.NewSimulatedClock(base.Add(500 * time.Millisecond)))
+	if err := r.ForwardIfReady(msg.Queue); err != nil {
+		t.Fatalf("(*RDB).ForwardIfReady failed: %v", err)
+	}
+	if got := h.GetScheduledMessages(t, r.client, msg.Queue); len(got) != 1 {
+		t.Fatalf("task forwarded before its process-at time: scheduled queue has %d tasks, want 1", len(got))
+	}
+	if got := h.GetPendingMessages(t, r.client, msg.Queue); len(got) != 0 {
+		t.Fatalf("task forwarded early: pending queue has %d tasks, want 0", len(got))
+	}
+
+	// Advance past processAt; the task should now be forwarded to pending.
+	r.SetClock(timeutil.NewSimulatedClock(base.Add(950 * time.Millisecond)))
+	if err := r.ForwardIfReady(msg.Queue); err != nil {
+		t.Fatalf("(*RDB).ForwardIfReady failed: %v", err)
+	}
+	if got := h.GetPendingMessages(t, r.client, msg.Queue); len(got) != 1 {
+		t.Fatalf("task not forwarded after its process-at time: pending queue has %d tasks, want 1", len(got))
+	}
+	if got := h.GetScheduledMessages(t, r.client, msg.Queue); len(got) != 0 {
+		t.Fatalf("task remained scheduled after its process-at time: scheduled queue has %d tasks, want 0", len(got))
 	}
 }
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -401,14 +401,14 @@ func TestProcessorRetry(t *testing.T) {
 		time.Sleep(tc.wait)   // FIXME: This makes test flaky.
 		p.shutdown()
 
-		cmpOpt := h.EquateInt64Approx(int64(tc.wait.Seconds())) // allow up to a wait-second difference in zset score
+		cmpOpt := h.EquateInt64Approx(tc.wait.Microseconds()) // allow up to a wait-second difference in zset score (scheduled/retry scores are in microseconds)
 		gotRetry := h.GetRetryEntries(t, r, base.DefaultQueueName)
 		var wantRetry []base.Z // Note: construct wantRetry here since `LastFailedAt` and ZSCORE is relative to each test run.
 		for _, msg := range tc.wantRetry {
 			wantRetry = append(wantRetry,
 				base.Z{
 					Message: h.TaskMessageAfterRetry(*msg, tc.wantErrMsg, runTime),
-					Score:   runTime.Add(tc.delay).Unix(),
+					Score:   runTime.Add(tc.delay).UnixMicro(),
 				})
 		}
 		if diff := cmp.Diff(wantRetry, gotRetry, h.SortZSetEntryOpt, cmpOpt); diff != "" {


### PR DESCRIPTION
Scheduled and retry task scores were stored in their Redis sorted sets with whole-second precision and the forwarder compared against now in seconds, so a task scheduled for :00.900 could be run as early as :00.000 — up to ~1s early.

Store the score in microseconds (UnixMicro) and compare in microseconds when forwarding. Microseconds, not nanoseconds: Redis sorted-set scores are float64, which represents integers exactly only up to 2^53 (~9e15); UnixNano (~1.8e18) would lose precision, while UnixMicro (~1.8e15) stays exact.

The forward script reused "now" as the score when moving a grouped task into its aggregation set; that score is kept in seconds via a new ARGV so grouping behavior is unchanged. The inspector now reads scheduled/retry scores back as microseconds.

Fixes issue #1071 